### PR TITLE
Fixed skip nav issue in safari

### DIFF
--- a/css/helpers.css
+++ b/css/helpers.css
@@ -18,10 +18,10 @@
 .skip-link {
   color: transparent;
   font-size: 12px;
-  height: 0;
+  /*height: 0;*/
   position: absolute; }
   .skip-link:focus {
-    color: #3575FF;
+    color: #B94650;
     height: auto;
     position: inherit;
     display: inline-block;

--- a/scss/helpers.scss
+++ b/scss/helpers.scss
@@ -19,10 +19,10 @@
 .skip-link {
 	color: transparent;
 	font-size: 12px;
-	height: 0;
+	/*height: 0;*/
 	position: absolute;
    &:focus {
-      color: $blue;
+      color: $rose;
 		height: auto;
 		position: inherit;
 		display: inline-block;


### PR DESCRIPTION
Having 0 height meant that the link never got focus in Safari.