### PR TITLE
Standardize the HTML page titles

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,17 +1,17 @@
 import Handlebars from 'handlebars/dist/handlebars.runtime';
 
-export function handlebarsHelper(helperName, helperFunc){
+export function handlebarsHelper(helperName, helperFunc) {
   return Handlebars.registerHelper(helperName, helperFunc);
 }
-export function handlebarsPartial(partialName, partialTemplate){
+export function handlebarsPartial(partialName, partialTemplate) {
   return Handlebars.registerPartial(partialName, partialTemplate);
 }
 
-export function activeElementMatches(matchList){
+export function activeElementMatches(matchList) {
   // the active element (with focus) isn't available yet when the blur event fires
   // so we kick this function down the stack a little with requestAnimationFrame
-  return new Promise(function(resolve) {
-    window.requestAnimationFrame(function(){
+  return new Promise(function (resolve) {
+    window.requestAnimationFrame(function () {
       const activeFocusElement = document.activeElement;
       resolve(activeFocusElement.matches(matchList));
     });
@@ -23,13 +23,13 @@ export function activeElementMatches(matchList){
  * @param {array} items
  * @param {number} size - number of items to put in each 'chunk'
  */
-export function chunk(items, size){
+export function chunk(items, size) {
   if (size === 0) return [[...items]];
   let chunked = [];
   let index = 0;
-  while (index < items.length){
+  while (index < items.length) {
     chunked.push(items.slice(index, index + size));
-    index +=size;
+    index += size;
   }
   return chunked;
 }
@@ -40,11 +40,11 @@ export function chunk(items, size){
  * @param {number} length - Size of subset array to return
  * @returns {array}
  */
-export function getRandomSubset(items, length){
+export function getRandomSubset(items, length) {
   let tempItems = [...items];
   let randomSubset = [];
-  for (let i = 0; i<length; i++){
-    let randomIndex = Math.floor(Math.random()*tempItems.length);
+  for (let i = 0; i < length; i++) {
+    let randomIndex = Math.floor(Math.random() * tempItems.length);
     randomSubset.push(tempItems.splice(randomIndex, 1)[0]);
   }
   return randomSubset;
@@ -97,4 +97,14 @@ export function getElementIndex(element) {
 
 export function normalizeName(str) {
   return str.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+}
+/**
+ * Set the document title
+ * @param  {Array} [terms] - list of terms to add after the site name
+ */
+export function setPageTitle(terms) {
+  const siteName = 'The Accessible eStore';
+  document.title = (terms)
+    ? `${siteName}, ${terms.join(', ')}`
+    : siteName;
 }

--- a/src/pages/cart/index.html
+++ b/src/pages/cart/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-    <title>Cart | The Accessibile eStore</title>
+    <title>The Accessibile eStore, Cart</title>
 
     <link rel="stylesheet" href="../../styles.scss">
 

--- a/src/pages/checkout/index.html
+++ b/src/pages/checkout/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-    <title>Checkout | The Accessibile eStore</title>
+    <title>The Accessibile eStore, Checkout</title>
 
     <link rel="stylesheet" href="../../styles.scss">
 

--- a/src/pages/order-confirmation/index.html
+++ b/src/pages/order-confirmation/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-    <title>Order Confirmation | The Accessibile eStore</title>
+    <title>The Accessibile eStore, Order Confirmation</title>
 
     <link rel="stylesheet" href="../../styles.scss">
 

--- a/src/pages/pdp/index.html
+++ b/src/pages/pdp/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-    <title>Product Detail page | The Accessibile eStore</title>
+    <title>The Accessible eStore</title>
 
     <link rel="stylesheet" href="../../styles.scss">
     <link rel="stylesheet" href="./pdp.scss">
@@ -23,12 +23,12 @@
                 <p class="error-message hidden">No product with that ID found. See <a href="../pdp/index.html?product_id=1">example page</a>.</p>
                 <div data-template="product-details"></div>
                 <div data-template="gallery"></div>
-              </section>
-              <section>
+            </section>
+            <section>
                 <div data-component="accordion">
-                  <div id="product-description" data-title="Product Description" data-component="product-description"></div>
-                  <div id="size-chart" data-title="Size Chart" data-component="size-chart"></div>
-                  <div id="ratings-reviews" data-title="Ratings & Reviews" data-component="product-ratings"></div>
+                    <div id="product-description" data-title="Product Description" data-component="product-description"></div>
+                    <div id="size-chart" data-title="Size Chart" data-component="size-chart"></div>
+                    <div id="ratings-reviews" data-title="Ratings & Reviews" data-component="product-ratings"></div>
                 </div>
             </section>
         </div>

--- a/src/pages/pdp/pdp.js
+++ b/src/pages/pdp/pdp.js
@@ -2,6 +2,7 @@ import * as breadcrumb from '../../components/breadcrumb/breadcrumb';
 import * as productDetails from '../../components/product-details/product-details';
 import * as productGallery from '../../components/gallery/gallery';
 import * as productForm from '../../components/product-form/product-form';
+import { setPageTitle } from '../../js/utils';
 import * as productDB from '../../js/pouchdb';
 
 (function pdpPage() {
@@ -14,7 +15,7 @@ import * as productDB from '../../js/pouchdb';
   }
 
   function loadProductData() {
-    productDB.getSingleRow(product_id).then(function(res) {
+    productDB.getSingleRow(product_id).then(function (res) {
       const productData = res.docs[0];
       const breadcrumbs = [
         { label: 'Home', link: '../index.html' },
@@ -22,6 +23,7 @@ import * as productDB from '../../js/pouchdb';
         { label: productData.subcategory, link: '../plp/index.html' },
         { label: productData.product_name }
       ];
+      setPageTitle(['Women', 'Women’s Tops', productData.product_name]);
       breadcrumb.init(breadcrumbs);
       productDetails.init(productData);
       productGallery.init(productData);

--- a/src/pages/plp/index.html
+++ b/src/pages/plp/index.html
@@ -1,42 +1,48 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
-		<title>Document</title>
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
-		<link rel="stylesheet" href="../../styles.scss" />
-		<link rel="stylesheet" href="./plp.scss" />
-	</head>
+    <title>The Accessible eStore</title>
 
-	<body class="page-plp">
-		<header data-template="global-header"></header>
-		<div data-template="breadcrumb"></div>
-		<div class="container">
-			<section id="content" class="main-content">
-				<h1 id="page-title" class="template-heading">Women’s Tops</h1>
-				<div class="mobile-filters">
-					<button class="mobile-filter" type="button" data-modal="filters">
-						Filters (6)
-						<svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="../../assets/sprite.svg#add"></use></svg>
-					</button>
-					<button class="mobile-filter" type="button" data-modal="sort">
-						Sort
-						<svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="../../assets/sprite.svg#add"></use></svg>
-					</button>
-				</div>
-				<div data-template="filters"></div>
-				<div data-template="sort"></div>
-				<div data-template="grid"></div>
-				<div data-template="pagination"></div>
-			</section>
-			<section data-template="carousel"></section>
-		</div>
-		<footer data-template="footer"></footer>
-		<div data-template="modal"></div>
-		<script src="../../scripts.js"></script>
-		<script src="./plp.js"></script>
-	</body>
+    <link rel="stylesheet" href="../../styles.scss" />
+    <link rel="stylesheet" href="./plp.scss" />
+</head>
+
+<body class="page-plp">
+    <header data-template="global-header"></header>
+    <div data-template="breadcrumb"></div>
+    <div class="container">
+        <section id="content" class="main-content">
+            <h1 id="page-title" class="template-heading">Women’s Tops</h1>
+            <div class="mobile-filters">
+                <button class="mobile-filter" type="button" data-modal="filters">
+                    Filters (6)
+                    <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <use xlink:href="../../assets/sprite.svg#add"></use>
+                    </svg>
+                </button>
+                <button class="mobile-filter" type="button" data-modal="sort">
+                    Sort
+                    <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <use xlink:href="../../assets/sprite.svg#add"></use>
+                    </svg>
+                </button>
+            </div>
+            <div data-template="filters"></div>
+            <div data-template="sort"></div>
+            <div data-template="grid"></div>
+            <div data-template="pagination"></div>
+        </section>
+        <section data-template="carousel"></section>
+    </div>
+    <footer data-template="footer"></footer>
+    <div data-template="modal"></div>
+    <script src="../../scripts.js"></script>
+    <script src="./plp.js"></script>
+</body>
+
 </html>

--- a/src/pages/plp/plp.js
+++ b/src/pages/plp/plp.js
@@ -5,7 +5,7 @@ import * as productSort from '../../components/product-sort/product-sort';
 import * as productGrid from '../../components/product-grid/product-grid';
 import * as pagination from '../../components/pagination/pagination';
 import * as carousel from '../../components/product-carousel/product-carousel';
-import { chunk, getRandomSubset } from '../../js/utils';
+import { chunk, getRandomSubset, setPageTitle } from '../../js/utils';
 import * as productDB from '../../js/pouchdb';
 
 (function plpPage() {
@@ -75,12 +75,13 @@ import * as productDB from '../../js/pouchdb';
   }
 
   function fetchComponentData() {
-    productDB.query(['rating'], currentQuery).then(function(result) {
+    productDB.query(['rating'], currentQuery).then(function (result) {
       updateAllProducts(result);
       const carouselItems = getRandomSubset(allProducts, CAROUSEL_ITEM_COUNT);
       carousel.update(carouselItems);
     });
   }
 
+  setPageTitle(['Women', 'Women’s Tops']);
   productDB.init().then(fetchComponentData);
 })();

--- a/src/pages/review-order/index.html
+++ b/src/pages/review-order/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-    <title>Review Order | The Accessibile eStore</title>
+    <title>The Accessibile eStore, Review Order</title>
 
     <link rel="stylesheet" href="../../styles.scss">
 


### PR DESCRIPTION
Issue #144 

* Set default page titles, update hard-coded titles for pages with static categories
* Add setPageTitle utility function
* Add calls to setPageTitle on pages with dynamic categories/content

There may be some whitespace changes. Trying to use auto-formatting
plugins to standardize everything.