### PR TITLE
Add ARIA-Live to Showing x of y on product filter

### DIFF
--- a/src/components/product-sort/product-sort.hbs
+++ b/src/components/product-sort/product-sort.hbs
@@ -1,32 +1,36 @@
 <section class="product-sort" id="product-sort" data-component="sort">
-  <h2 class="heading heading--section">Sort</h2>
-  <span class="sort__showing-count" data-template="showing-count"></span>
-  <div class="product-sort__options">
-    <div class="product-sort__option">
-      <h3 class="form--label"><label for="sortBy">Sort By</label></h3>
-      <select class="sort-menu__select select--block" data-js="update-sort" name="sort-by" id="sortBy">
-        <option value="rating:desc">Newest</option>
-        <option value="price_sale:desc">Price high to low</option>
-        <option value="price_sale:asc">Price low to high</option>
-      </select>
-      <a id="skip-to-sort" href="#skip-to-products-from-sort" class="skip-link">Skip to products</a>
+    <h2 class="heading heading--section">Sort</h2>
+    <span class="sort__showing-count" aria-live="polite" aria-atomic="true">
+        Showing
+        <span data-js="showing-count"></span>
+        <span class="sr-only">products</span>
+    </span>
+    <div class="product-sort__options">
+        <div class="product-sort__option">
+            <h3 class="form--label"><label for="sortBy">Sort By</label></h3>
+            <select class="sort-menu__select select--block" data-js="update-sort" name="sort-by" id="sortBy">
+                <option value="rating:desc">Newest</option>
+                <option value="price_sale:desc">Price high to low</option>
+                <option value="price_sale:asc">Price low to high</option>
+            </select>
+            <a id="skip-to-sort" href="#skip-to-products-from-sort" class="skip-link">Skip to products</a>
+        </div>
+        <div class="product-sort__option">
+            <h3 class="form--label"><label for="itemsPerPage">Items Per Page</label></h3>
+            <select class="sort-menu__select select--block" data-js="update-ipp" name="items-per-page" id="itemsPerPage">
+                <option value="12">12</option>
+                <option value="24">24</option>
+                <option value="0">All</option>
+            </select>
+            <a href="#skip-to-products-from-sort" class="skip-link">Skip to products</a>
+        </div>
+        <div class="product-sort__option">
+            <h3 class="form--label"><label for="viewBy">View By</label></h3>
+            <select class="sort-menu__select select--block" data-js="update-view" name="view-by" id="viewBy">
+                <option value="grid_view">Grid View</option>
+                <option value="list_view">List View</option>
+            </select>
+            <a href="#skip-to-products-from-sort" class="skip-link">Skip to products</a>
+        </div>
     </div>
-    <div class="product-sort__option">
-      <h3 class="form--label"><label for="itemsPerPage">Items Per Page</label></h3>
-      <select class="sort-menu__select select--block" data-js="update-ipp" name="items-per-page" id="itemsPerPage">
-        <option value="12">12</option>
-        <option value="24">24</option>
-        <option value="0">All</option>
-      </select>
-      <a href="#skip-to-products-from-sort" class="skip-link">Skip to products</a>
-    </div>
-    <div class="product-sort__option">
-      <h3 class="form--label"><label for="viewBy">View By</label></h3>
-      <select class="sort-menu__select select--block" data-js="update-view" name="view-by" id="viewBy">
-        <option value="grid_view">Grid View</option>
-        <option value="list_view">List View</option>
-      </select>
-      <a href="#skip-to-products-from-sort" class="skip-link">Skip to products</a>
-    </div>
-  </div>
 </section>

--- a/src/components/product-sort/product-sort.js
+++ b/src/components/product-sort/product-sort.js
@@ -1,12 +1,11 @@
 import renderSort from './product-sort.hbs';
-import renderShowingCount from './showing-count.hbs';
 
 let itemsPerPage = 12;
 let showingCountElement;
 let showing = {};
 
 function formatSortOptions(value) {
-  if (!value) return { newest: 'desc'};
+  if (!value) return { newest: 'desc' };
 
   const [sortBy, sortDirection] = value.split(':');
   let sortOptions = {};
@@ -29,12 +28,12 @@ function onIppChange(event) {
 
 function init() {
   const element = document.querySelector('[data-template="sort"]');
-  if (element){
+  if (element) {
     element.outerHTML = renderSort();
-    const componentEl = document.querySelector('[data-component="sort"]')
+    const componentEl = document.querySelector('[data-component="sort"]');
     const sortFilter = componentEl.querySelector('[data-js="update-sort"]');
     const ippFilter = componentEl.querySelector('[data-js="update-ipp"]');
-    showingCountElement = componentEl.querySelector('[data-template="showing-count"]');
+    showingCountElement = componentEl.querySelector('[data-js="showing-count"]');
     sortFilter.addEventListener('change', onSortChange);
     ippFilter.addEventListener('change', onIppChange);
   }
@@ -44,10 +43,10 @@ function update(index, total) {
   if (total) showing.total = total;
   showing.start = index * itemsPerPage + 1;
   showing.end = (itemsPerPage > 0) ? Math.min((index + 1) * itemsPerPage, showing.total) : showing.total;
-  showingCountElement.innerHTML = renderShowingCount(showing);
+  showingCountElement.innerHTML = `${showing.start} to ${showing.end} of ${showing.total}`;
 }
 
-function getItemsPerPage(){
+function getItemsPerPage() {
   return itemsPerPage;
 }
 

--- a/src/components/product-sort/showing-count.hbs
+++ b/src/components/product-sort/showing-count.hbs
@@ -1,1 +1,0 @@
-Showing {{start}} <span class="element-invisible">to</span><span aria-hidden="true">-</span> {{end}} of {{total}} <span class="element-invisible">products</span>


### PR DESCRIPTION
Issue: #148

* Had to remove the Handlebars approach and replace with a simple string
and some code re-org. After a lot of investigation, I found that
ARIA-Live doesn't work well if the replaced contents include HTML
elements. Text-only swaps are ideal, otherwise there's unwanted
side-effects like the read-order changing or the SR will only read the
content that's changed (despite different settings for `ARIA-atomic`).

* Because of the above issue, we couldn't use spans anymore to hide the
'to' visually and hide the dash from the SR. So, I had to change:
`1 - 12 of 40` to:
`1 to 12 of 40`

* Removed now deprecated showing-count.hbs

Again, there's some whitespace changes. You'll want to turn them off in the diff view for a better idea of the changes.