### PR TITLE
Update visible focus indicator styles

### DIFF
--- a/src/scss/_inputs.scss
+++ b/src/scss/_inputs.scss
@@ -6,15 +6,19 @@
   &__input {
     opacity: 0;
     position: absolute;
+
     &:checked+label {
       &::after {
         content: "";
       }
     }
+
     &:focus+label::before {
-      outline: rgb(59, 153, 252) auto 5px;
+      outline: 2px solid $focus-indicator;
+      outline-offset: 2px;
     }
   }
+
   &__label {
     position: relative;
     display: flex;
@@ -23,6 +27,7 @@
     margin-right: $grid-unit * 2;
     cursor: pointer;
     font-size: $font-xs;
+
     &::before {
       background-color: $white;
       border: 1px solid;
@@ -33,6 +38,7 @@
       height: $input-size;
       width: $input-size;
     }
+
     &::after {
       background: $black;
       border-radius: 50%;
@@ -50,16 +56,21 @@
   &__input {
     opacity: 0;
     position: absolute;
+
     &:checked+label {
       font-weight: bold;
+
       &::after {
         content: "";
       }
     }
+
     &:focus+label::before {
-      outline: rgb(59, 153, 252) auto 5px;
+      outline: 2px solid $focus-indicator;
+      outline-offset: 2px;
     }
   }
+
   &__label {
     position: relative;
     display: inline-flex;
@@ -68,6 +79,7 @@
     margin-right: 8px;
     cursor: pointer;
     font-size: $font-xs;
+
     &::before {
       border: 1px solid $yet-another-grey;
       border-radius: 4px;
@@ -77,6 +89,7 @@
       height: $input-size;
       width: $input-size;
     }
+
     &::after {
       height: 5px;
       width: 14px;
@@ -108,6 +121,7 @@ select {
   background-size: 14px;
   background-position: right 12px center;
   position: relative;
+
   &.select--block {
     width: 100%;
   }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -10,6 +10,7 @@ $light-grey: #e7e7e7;
 $grey: #d8d8d8;
 $yet-another-grey: #b5b5b5;
 $medium-grey: #9b9b9b;
+$focus-indicator: #0097F5;
 
 $rose: #b94650;
 $dark-rose: #90373d;
@@ -44,7 +45,10 @@ $grid-unit: 6px;
 
 $input-size: 24px;
 
-$font-sans: Verdana, Geneva, Tahoma, sans-serif;
+$font-sans: Verdana,
+Geneva,
+Tahoma,
+sans-serif;
 
 // =========================================== FONT SIZES
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,56 +6,73 @@
 
 /* ============================== Global Styles */
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
-h1, h2, h3, h4, h5, h6{
-    font-weight: 500;
-}
-fieldset{
-    border: 0;
-    padding: 0;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 500;
 }
 
-/* a:not(.btn) {
-    color: $black;
-} */
-p{
-    line-height: 1.3;
+fieldset {
+  border: 0;
+  padding: 0;
+}
+
+p {
+  line-height: 1.3;
 }
 
 html {
-    font-size: 62.5%; // (for REM): 62.5% = 10px for most browsers if the default font size is 16px.
+  font-size: 62.5%; // (for REM): 62.5% = 10px for most browsers if the default font size is 16px.
 }
 
 body {
-    font-family: $font-sans;
-    font-size: $font-md; // 1.6rem (16px) for most browsers
-    margin: 0;
-    color: $black;
-    background-color: $warm-grey;
+  font-family: $font-sans;
+  font-size: $font-md; // 1.6rem (16px) for most browsers
+  margin: 0;
+  color: $black;
+  background-color: $warm-grey;
 }
 
-svg{
-    fill: currentColor;
+svg {
+  fill: currentColor;
 }
 
-button{
-    font-family: $font-sans;
+button {
+  font-family: $font-sans;
 }
 
-.heading--section{
-    font-size: $font-lg;
-    font-weight: bold;
-    margin-top: 2.4rem;
+.heading--section {
+  font-size: $font-lg;
+  font-weight: bold;
+  margin-top: 2.4rem;
 }
-button, input, a{
-    &:focus{
-        outline: 1px dotted currentColor;
-    }
-    &::-moz-focus-inner {
-        border:0;
-    }
+
+button,
+input,
+select,
+a {
+  &:focus {
+    outline: 2px solid $focus-indicator;
+    outline-offset: 2px;
+  }
+
+  // Firefox hack :(
+  &::-moz-focus-inner {
+    border: 0;
+  }
+}
+
+// Firefox hack :(
+select:-moz-focusring,
+select::-moz-focus-inner {
+  color: transparent !important;
+  text-shadow: 0 0 0 $black;
 }
 
 @import "./scss/helpers";


### PR DESCRIPTION
Feature: #160

* Add focus-indicator blue to variables.scss
* Update global focus styling
* Update custom styling for custom inputs (radio/checkbox)
* Add `-moz` prefixed styling to remove redundant firefox focus
indicators