### PR TITLE
Feature/gh 123 mobile filter sort modals

### DIFF
--- a/src/components/gallery/gallery-modal.hbs
+++ b/src/components/gallery/gallery-modal.hbs
@@ -1,13 +1,14 @@
-<div id="gallery-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalDesc">
+<div id="gallery-modal" class="modal gallery-modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalDesc">
   <div class="modal__flex">
     <div class="modal__content">
       <button class="modal__close" data-modal-hide="gallery-modal">
         <span class="sr-only">close</span>
-        <svg class="icon icon-close">
+        <svg class="icon icon--close">
           <use xlink:href="../sprite.svg#close"></use>
         </svg>
       </button>
-      <img src="#" alt="">
+      <img class="gallery-modal__image" src="#" alt="">
     </div>
   </div>
+  <button tabindex="-1" class="modal__backdrop-close" data-modal-hide="gallery-modal"></button>
 </div>

--- a/src/components/header/header.hbs
+++ b/src/components/header/header.hbs
@@ -8,7 +8,7 @@
   </a>
   <div class="global-header__mobile-toggles">
     <button class="btn btn--mobile btn--mobile-search" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="search" aria-label="search">
-      <span class="sr-only">Search</span>
+      Search
       <svg class="icon icon--menu-btn">
         <use xlink:href="{{rootPath}}/sprite.svg#search"></use>
       </svg>

--- a/src/components/header/header.hbs
+++ b/src/components/header/header.hbs
@@ -1,4 +1,4 @@
-<a class="skip-link" id="skip-to-main" href="#skip-to-nav">Skip navigation menu</a>
+<a class="skip-link" id="skip-to-main" href="#skip-to-nav" tabindex="0">Skip navigation menu</a>
 <header class="global-header" data-component="global-header">
   <a class="global-header__logo" href="{{rootPath}}/index.html">
     <span class="global-header__site-icon" aria-hidden="true">A</span>
@@ -186,4 +186,4 @@
     </ul>
   </nav>
 </header>
-<a class="skip-link" id="skip-to-nav" href="#skip-to-main">Return to navigation menu</a>
+<a class="skip-link" id="skip-to-nav" href="#skip-to-main" tabindex="0">Return to navigation menu</a>

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -1,69 +1,81 @@
 @import '../../scss/mixins';
 @import '../../scss/variables';
 
+body.modal-open {
+  overflow: hidden;
+  position: fixed;
+}
+
 .modal {
-    display: none; 
-    position: fixed; 
-    z-index: 200; 
-    left: 0;
-    top: 0;
-    width: 100%; 
-    height: 100%; 
-    overflow: auto; 
-    background-color: rgb(31,31,31); 
-    background-color: rgba(31,31,31,0.75); 
+  display: none;
+  position: fixed;
+  z-index: 200;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(31, 31, 31);
+  background-color: rgba(31, 31, 31, 0.75);
 
-    &__flex {
-        display: flex;
-        justify-content: center;
+  &[aria-expanded="true"] {
+    display: block;
+  }
+
+  &__flex {
+    display: flex;
+    justify-content: center;
+  }
+
+
+  &__content {
+    margin-top: 5rem;
+    padding: 40px;
+    background-color: $white;
+    position: relative;
+
+    h2 {
+      color: $black;
+      font-size: $font-xxl;
+      font-weight: bold;
+      letter-spacing: -0.9px;
+      line-height: 29px;
+      margin-top: 0px;
     }
 
-  
-    &__content {
-        margin-top: 5rem; 
-        padding: 40px;
-        background-color: $white; 
-        position: relative;
+    p {
+      color: #000000;
+      letter-spacing: -0.5px;
+      line-height: 24px;
+    }
+  }
 
-        h2 {
-            color: $black;	
-            font-size: $font-xxl;	
-            font-weight: bold;	
-            letter-spacing: -0.9px;	
-            line-height: 29px;
-            margin-top: 0px;
-        }
+  #construction-modal &__content {
+    width: 420px;
+  }
 
-        p {
-            color: #000000;	
-            letter-spacing: -0.5px;	
-            line-height: 24px;
-        }
-    }
-    #construction-modal &__content {
-        width: 420px;	
-    }
-    &__close {
-        position: absolute;
-        right: -16px;
-        top: -16px;
-        height: 32px;
-        width: 32px;
-        border-radius: 16px;
-        border-width: 0;
-        color: #000000;
-        font-size: 18px;
-        font-weight: bold;
-        @include medium-shadow;
-        cursor: pointer;
+  &__close {
+    position: absolute;
+    right: -16px;
+    top: -16px;
+    height: 32px;
+    width: 32px;
+    border-radius: 16px;
+    border-width: 0;
+    color: #000000;
+    font-size: 18px;
+    font-weight: bold;
+    @include medium-shadow;
+    cursor: pointer;
 
-        .icon-close {
-            height: 18px;
-            width: 18px;
-            margin-top: 5px;
-        }
+    .icon-close {
+      height: 18px;
+      width: 18px;
+      margin-top: 5px;
     }
-    .btn {
-        width: 178px;
-    }
+  }
+
+  .btn {
+    width: 178px;
+  }
 }

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -3,7 +3,6 @@
 
 body.modal-open {
   overflow: hidden;
-  position: fixed;
 }
 
 .modal {
@@ -27,32 +26,20 @@ body.modal-open {
     justify-content: center;
   }
 
-
   &__content {
-    margin-top: 5rem;
+    margin: 5rem 24px 0;
     padding: 40px;
     background-color: $white;
     position: relative;
+    z-index: 10;
 
-    h2 {
-      color: $black;
-      font-size: $font-xxl;
-      font-weight: bold;
-      letter-spacing: -0.9px;
-      line-height: 29px;
-      margin-top: 0px;
-    }
-
-    p {
-      color: #000000;
-      letter-spacing: -0.5px;
-      line-height: 24px;
+    .modal--dynamic & {
+      margin: 0;
+      padding: 16px 0;
     }
   }
 
-  #construction-modal &__content {
-    width: 420px;
-  }
+
 
   &__close {
     position: absolute;
@@ -68,14 +55,59 @@ body.modal-open {
     @include medium-shadow;
     cursor: pointer;
 
-    .icon-close {
+    .icon--close {
       height: 18px;
       width: 18px;
       margin-top: 5px;
     }
+
+    .modal--dynamic & {
+      box-shadow: none;
+      right: 8px;
+      top: 8px;
+      padding: 0;
+      background: transparent;
+    }
   }
 
-  .btn {
-    width: 178px;
+  &__backdrop-close {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 0;
+    border: 0;
+    background: transparent;
+  }
+}
+
+.gallery-modal {
+  &__image {
+    max-width: 100%;
+  }
+}
+
+.construction-modal {
+  &__content {
+    max-width: 420px;
+  }
+
+  &__title {
+    font-size: $font-xxl;
+    font-weight: bold;
+    letter-spacing: -0.9px;
+    line-height: 29px;
+    margin-top: 0px;
+  }
+
+  &__description {
+    letter-spacing: -0.5px;
+    line-height: 24px;
+    margin-bottom: 24px;
+  }
+
+  &__cta-btn {
+    width: 180px;
   }
 }

--- a/src/components/modal/construction-modal.hbs
+++ b/src/components/modal/construction-modal.hbs
@@ -1,15 +1,16 @@
-<div id="construction-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalDesc">
+<div id="construction-modal" class="modal construction-modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalDesc">
   <div class="modal__flex">
-    <div class="modal__content">
+    <div class="modal__content construction-modal__content">
       <button class="modal__close" data-modal-hide="construction-modal">
         <span class="sr-only">close</span>
-        <svg class="icon icon-close">
+        <svg class="icon icon--close">
           <use xlink:href="../sprite.svg#close"></use>
         </svg>
       </button>
-      <h2 id="modalTitle">Coming soon!</h2>
-      <p id="modalDesc">This element is under construction. It currently lacks functionality, but it is planned to be developed in the coming months. Check back soon.</p>
-      <button class="btn" aria-label="close modal" data-modal-hide="construction-modal">Close</button>
+      <h2 id="modalTitle" class="construction-modal__title">Coming soon!</h2>
+      <p id="modalDesc" class="construction-modal__description">This element is under construction. It currently lacks functionality, but it is planned to be developed in the coming months. Check back soon.</p>
+      <button class="btn construction-modal__cta-btn" aria-label="close modal" data-modal-hide="construction-modal">Close</button>
     </div>
   </div>
+  <button tabindex="-1" class="modal__backdrop-close" data-modal-hide="construction-modal"></button>
 </div>

--- a/src/components/modal/modal-dynamic.hbs
+++ b/src/components/modal/modal-dynamic.hbs
@@ -1,0 +1,11 @@
+<div class="modal" role="dialog" aria-modal="true" aria-expanded="true">
+    <div class="modal-content">
+        <button class="close modal-close" aria-label="close modal">
+            <span class="sr-only">Close</span>
+            <svg class="icon">
+                <use xlink:href="../sprite.svg#close"></use>
+            </svg>
+        </button>
+        This is a modal
+    </div>
+</div>

--- a/src/components/modal/modal-dynamic.hbs
+++ b/src/components/modal/modal-dynamic.hbs
@@ -1,11 +1,12 @@
-<div class="modal" role="dialog" aria-modal="true" aria-expanded="true">
-    <div class="modal-content">
-        <button class="close modal-close" aria-label="close modal">
+<div class="modal modal--dynamic" id="{{modalId}}" role="dialog" aria-modal="true" aria-expanded="true">
+    <div class="modal__content">
+        <button class="close modal__close" data-js="close-modal" aria-label="close modal">
             <span class="sr-only">Close</span>
-            <svg class="icon">
+            <svg class="icon icon--close">
                 <use xlink:href="../sprite.svg#close"></use>
             </svg>
         </button>
-        This is a modal
+        <div class="modal__inner"></div>
     </div>
+    <button tabindex="-1" class="modal__backdrop-close" data-js="close-modal"></button>
 </div>

--- a/src/components/modal/modal-dynamic.js
+++ b/src/components/modal/modal-dynamic.js
@@ -1,17 +1,89 @@
 import renderModal from './modal-dynamic.hbs';
+import { setFocusToFirstItem, trapTabKey } from '../../js/utils';
 
-function init() {
-  const newModal = document.createElement('div');
-  const contentWrapper = document.createElement('div');
-  const bodyChildren = Array.from(document.body.children);
-  bodyChildren.forEach(function pushIntoWrapper(element) {
-    contentWrapper.appendChild(element);
+let contentWrapper;
+let bodyChildren;
+let originalContent = {};
+let modalElement;
+let mediaQueryList;
+let focusedElementBeforeModal;
+
+function onKeyDown(event) {
+  if (event.which === 27) {
+    event.preventDefault();
+    closeModal(modalElement);
+  }
+
+  if (event.which === 9) {
+    trapTabKey(modalElement, event);
+  }
+}
+
+function moveChildren(childElements, toElement) {
+  childElements.forEach(function pushChild(element) {
+    toElement.appendChild(element);
   });
+}
+
+function disableBodyContent() {
+  bodyChildren = Array.from(document.body.children);
+  contentWrapper = document.createElement('div');
+  moveChildren(bodyChildren, contentWrapper);
   contentWrapper.setAttribute('aria-hidden', 'true');
   document.body.appendChild(contentWrapper);
+}
+
+function storeOriginalElement(elementQuery) {
+  originalContent.element = document.querySelector(elementQuery);
+  originalContent.parent = originalContent.element.parentElement;
+  originalContent.sibling = originalContent.element.nextSibling;
+
+  return originalContent.element;
+}
+
+function createNewModal(elementQuery, modalId) {
+  const modalPlaceholder = document.createElement('div');
+  document.body.appendChild(modalPlaceholder);
+  modalPlaceholder.outerHTML = renderModal({ modalId });
   document.body.classList.add('modal-open');
-  document.body.appendChild(newModal);
-  newModal.outerHTML = renderModal();
+
+  const modalContent = storeOriginalElement(elementQuery);
+  modalElement = document.querySelector(`#${modalId}`);
+  modalElement.querySelector('.modal__inner').appendChild(modalContent);
+  modalElement.querySelectorAll('[data-js="close-modal"]')
+    .forEach(closeButton => closeButton.addEventListener('click', onCloseClick));
+  setFocusToFirstItem(modalElement);
+}
+
+function closeModal(currentModal) {
+  moveChildren(bodyChildren, document.body);
+  document.body.classList.remove('modal-open');
+  contentWrapper.remove();
+  currentModal.remove();
+  originalContent.parent.insertBefore(originalContent.element, originalContent.sibling);
+  document.removeEventListener('keydown', onKeyDown);
+  mediaQueryList.removeListener(checkBreakpoint);
+  focusedElementBeforeModal.focus();
+}
+
+function onCloseClick(event) {
+  const currentModal = event.target.closest('.modal');
+  closeModal(currentModal);
+}
+
+function checkBreakpoint(event) {
+  if (!event.matches) {
+    closeModal(modalElement);
+  }
+}
+
+function init(elementQuery, modalId) {
+  focusedElementBeforeModal = document.activeElement;
+  disableBodyContent();
+  createNewModal(elementQuery, modalId);
+  document.addEventListener('keydown', onKeyDown);
+  mediaQueryList = window.matchMedia('(max-width: 760px)');
+  mediaQueryList.addListener(checkBreakpoint);
 }
 
 export { init };

--- a/src/components/modal/modal-dynamic.js
+++ b/src/components/modal/modal-dynamic.js
@@ -1,0 +1,17 @@
+import renderModal from './modal-dynamic.hbs';
+
+function init() {
+  const newModal = document.createElement('div');
+  const contentWrapper = document.createElement('div');
+  const bodyChildren = Array.from(document.body.children);
+  bodyChildren.forEach(function pushIntoWrapper(element) {
+    contentWrapper.appendChild(element);
+  });
+  contentWrapper.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(contentWrapper);
+  document.body.classList.add('modal-open');
+  document.body.appendChild(newModal);
+  newModal.outerHTML = renderModal();
+}
+
+export { init };

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,63 +1,63 @@
 import { trapTabKey, $$, setFocusToFirstItem } from '../../js/utils';
 
 var Modal = function (element, mainSelector) {
-    this.element = element;
-    this.focusedElementBeforeModal;
-    this.main = document.querySelector(mainSelector) || document.body;
-  
-    this.shown = false;
-  
-    this.initEvents();
-  };
-  
-  Modal.prototype = {
-    onKeyDown: function(event){
-      if (this.shown && event.which === 27) {
-        event.preventDefault();
-        this.hide();
-      }
-  
-      if (this.shown && event.which === 9) {
-        trapTabKey(this.element, event);
-      }
-    },
-    onFocus: function(){
-      if (this.shown && !this.element.contains(event.target)) {
-        setFocusToFirstItem(this.element);
-      }
-    },
-    show: function() {
-      this.shown = true;
-      this.element.style.display='block';
-      this.element.setAttribute('aria-hidden', 'false');
-      this.element.setAttribute('aria-expanded', 'true');
-      this.main.setAttribute('aria-hidden', 'true');
-      this.focusedElementBeforeModal = document.activeElement;
-      setFocusToFirstItem(this.element);
-    },
-    hide: function() {
-      this.shown = false;
-      this.element.style.display='none';
-      this.element.setAttribute('aria-hidden', 'true');
-      this.element.setAttribute('aria-expanded', 'false');
-      this.main.setAttribute('aria-hidden', 'false');
-      this.focusedElementBeforeModal.focus();
-    },
-    initEvents: function(){
+  this.element = element;
+  this.focusedElementBeforeModal;
+  this.main = document.querySelector(mainSelector) || document.body;
 
-      document.addEventListener('keydown', this.onKeyDown.bind(this));
-  
-      document.body.addEventListener('focus', this.onFocus.bind(this), true);
+  this.shown = false;
 
-      $$('[data-modal-show="' + this.element.id + '"]').forEach( opener => opener.addEventListener('click', this.show.bind(this)) );
+  this.initEvents();
+};
 
-      $$('[data-modal-hide]', this.element).concat($$('[data-modal-hide="' + this.element.id + '"]')).forEach( closer => closer.addEventListener('click', this.hide.bind(this)) );
+Modal.prototype = {
+  onKeyDown: function (event) {
+    if (this.shown && event.which === 27) {
+      event.preventDefault();
+      this.hide();
     }
-  };
-  
-  function init(modalElementID) {
-    var modalElement = document.querySelector('#'+modalElementID);
-    new Modal(modalElement, '#content');
-  }
 
-  export {init};
+    if (this.shown && event.which === 9) {
+      trapTabKey(this.element, event);
+    }
+  },
+  onFocus: function () {
+    if (this.shown && !this.element.contains(event.target)) {
+      setFocusToFirstItem(this.element);
+    }
+  },
+  show: function () {
+    this.shown = true;
+    this.element.style.display = 'block';
+    this.element.setAttribute('aria-hidden', 'false');
+    this.element.setAttribute('aria-expanded', 'true');
+    this.main.setAttribute('aria-hidden', 'true');
+    this.focusedElementBeforeModal = document.activeElement;
+    setFocusToFirstItem(this.element);
+  },
+  hide: function () {
+    this.shown = false;
+    this.element.style.display = 'none';
+    this.element.setAttribute('aria-hidden', 'true');
+    this.element.setAttribute('aria-expanded', 'false');
+    this.main.setAttribute('aria-hidden', 'false');
+    this.focusedElementBeforeModal.focus();
+  },
+  initEvents: function () {
+
+    document.addEventListener('keydown', this.onKeyDown.bind(this));
+
+    document.body.addEventListener('focus', this.onFocus.bind(this), true);
+
+    $$('[data-modal-show="' + this.element.id + '"]').forEach(opener => opener.addEventListener('click', this.show.bind(this)));
+
+    $$('[data-modal-hide]', this.element).concat($$('[data-modal-hide="' + this.element.id + '"]')).forEach(closer => closer.addEventListener('click', this.hide.bind(this)));
+  }
+};
+
+function init(modalElementID) {
+  var modalElement = document.querySelector('#' + modalElementID);
+  new Modal(modalElement, '#content');
+}
+
+export { init };

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -26,21 +26,22 @@ Modal.prototype = {
       setFocusToFirstItem(this.element);
     }
   },
-  show: function () {
+  show: function (event) {
+    event.preventDefault();
     this.shown = true;
-    this.element.style.display = 'block';
     this.element.setAttribute('aria-hidden', 'false');
     this.element.setAttribute('aria-expanded', 'true');
     this.main.setAttribute('aria-hidden', 'true');
+    document.body.classList.add('modal-open');
     this.focusedElementBeforeModal = document.activeElement;
     setFocusToFirstItem(this.element);
   },
   hide: function () {
     this.shown = false;
-    this.element.style.display = 'none';
     this.element.setAttribute('aria-hidden', 'true');
     this.element.setAttribute('aria-expanded', 'false');
     this.main.setAttribute('aria-hidden', 'false');
+    document.body.classList.remove('modal-open');
     this.focusedElementBeforeModal.focus();
   },
   initEvents: function () {

--- a/src/components/product-filters/product-filters.hbs
+++ b/src/components/product-filters/product-filters.hbs
@@ -1,19 +1,37 @@
-<section aria-label="Filters" class="product-filters" data-component="filters">
-    <h2 class="heading heading--section">Filters</h2>
-    <a id="skip-to-products-from-filters-heading" class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
-    <p class="product-filters__filter-count" aria-live="polite" aria-atomic="true" data-js="filter-count">
-        0 filters applied
-    </p>
-    <p class="element-invisible">Showing <span data-js="product-count">0</span> products</p>
-    <h3 class="sr-only" id="remove-filter-description">Remove filter</h3>
-    <div data-component="active-filters"></div>
-    <button class="btn btn--link active-filters__clear-btn" data-js="clear-filters" type="button">
-        Clear filters
+<div class="mobile-filters">
+    <button class="mobile-filter" type="button" data-modal-load="filters">
+        Filters <span data-js="mobile-filter-count" aria-hidden="true">(0)</span>
         <span class="sr-only">, </span>
         <span class="sr-only" data-js="filter-count">0 filters applied</span>
+        <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <use xlink:href="../sprite.svg#add"></use>
+        </svg>
     </button>
-    <a id="skip-to-filters" class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
-    <ul class="accordion filters__accordion">
+    <button class="mobile-filter" type="button" data-modal-load="sort">
+        Sort
+        <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <use xlink:href="../sprite.svg#add"></use>
+        </svg>
+    </button>
+</div>
+<section aria-label="Filters" class="product-filters" data-component="filters">
+    <div class="product-filters__header">
+        <h2 class="heading heading--section">Filters</h2>
+        <a id="skip-to-products-from-filters-heading" class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
+        <p class="product-filters__filter-count" aria-live="polite" aria-atomic="true" data-js="filter-count">
+            0 filters applied
+        </p>
+        <p class="element-invisible">Showing <span data-js="product-count">0</span> products</p>
+        <h3 class="sr-only" id="remove-filter-description">Remove filter</h3>
+        <div data-component="active-filters"></div>
+        <button class="btn btn--link active-filters__clear-btn" data-js="clear-filters" type="button">
+            Clear filters
+            <span class="sr-only">, </span>
+            <span class="sr-only" data-js="filter-count">0 filters applied</span>
+        </button>
+        <a id="skip-to-filters" class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
+    </div>
+    <ul class="accordion product-filters__accordion">
         <li class="filter">
             <h3 class="accordion__heading filter__heading">
                 <button class="filter__toggle accordion__toggle" type="button" aria-expanded="true" data-js="accordion-toggle">
@@ -27,15 +45,15 @@
             <fieldset class="accordion__panel filter__options">
                 <legend id="colorLegend" class="visibly-hidden">Filter by Colors</legend>
                 <input id="blue" data-js="filter" class="checkbox__input" aria-label="Filter on color blue" type="checkbox" name="color" value="blue">
-                <label for="blue" class="checkbox__label">Blue</label><br>
+                <label for="blue" class="checkbox__label">Blue</label>
                 <input id="green" data-js="filter" class="checkbox__input" aria-label="Filter on color green" type="checkbox" name="color" value="green">
-                <label for="green" class="checkbox__label">Green</label><br>
+                <label for="green" class="checkbox__label">Green</label>
                 <input id="yellow" data-js="filter" class="checkbox__input" aria-label="Filter on color yellow" type="checkbox" name="color" value="yellow">
-                <label for="yellow" class="checkbox__label">Yellow</label><br>
+                <label for="yellow" class="checkbox__label">Yellow</label>
                 <input id="red" data-js="filter" class="checkbox__input" aria-label="Filter on color red" type="checkbox" name="color" value="red">
                 <label for="red" class="checkbox__label">Red</label>
+                <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
             </fieldset>
-            <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
         </li>
         <li class="filter">
             <h3 class="accordion__heading filter__heading">
@@ -50,13 +68,13 @@
             <fieldset class="accordion__panel filter__options">
                 <legend id="sizeLegend" class="visibly-hidden">Filter by Size</legend>
                 <input id="large" data-js="filter" class="checkbox__input" aria-label="Filter on size large" type="checkbox" name="size" value="large" />
-                <label for="large" class="checkbox__label">Large</label><br>
+                <label for="large" class="checkbox__label">Large</label>
                 <input id="medium" data-js="filter" class="checkbox__input" aria-label="Filter on size medium" type="checkbox" name="size" value="medium">
-                <label for="medium" class="checkbox__label">Medium</label><br>
+                <label for="medium" class="checkbox__label">Medium</label>
                 <input id="small" data-js="filter" class="checkbox__input" aria-label="Filter on size small" type="checkbox" name="size" value="small">
-                <label for="small" class="checkbox__label">Small</label><br>
+                <label for="small" class="checkbox__label">Small</label>
+                <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
             </fieldset>
-            <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
         </li>
         <li class="filter">
             <h3 class="accordion__heading filter__heading">
@@ -84,13 +102,18 @@
                 <button class="btn btn--link price-filter__clear-btn" type="button" data-js="price-range-clear">
                     Clear price range
                 </button>
+                <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
             </form>
-            <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
         </li>
     </ul>
-    <button class="btn btn--link active-filters__clear-btn" data-js="clear-filters" type="button">
-        Clear filters
-        <span class="sr-only">, </span>
-        <span class="sr-only" data-js="filter-count">0 filters applied</span>
-    </button>
+    <div class="product-filters__footer">
+        <button class="btn active-filters__close-btn" data-js="close-modal" type="button">
+            I’m done
+        </button>
+        <button class="btn btn--link active-filters__clear-btn" data-js="clear-filters" type="button">
+            Clear filters
+            <span class="sr-only">, </span>
+            <span class="sr-only" data-js="filter-count">0 filters applied</span>
+        </button>
+    </div>
 </section>

--- a/src/components/product-filters/product-filters.js
+++ b/src/components/product-filters/product-filters.js
@@ -6,6 +6,7 @@ import * as accordion from '../accordion/accordion';
 let componentEl;
 let activeFiltersEl;
 let filterCountEls;
+let mobileFilterCount;
 let priceFilterForm;
 let priceFromField;
 let priceToField;
@@ -65,6 +66,10 @@ function updateFilters() {
     ? 'filter'
     : 'filters';
 
+  mobileFilterCount.innerHTML = (activeFilters.length)
+    ? `&nbsp;(${activeFilters.length})`
+    : '';
+
   filterCountEls.forEach(element =>
     element.innerHTML =
     `${activeFilters.length} ${filterText} applied`
@@ -110,6 +115,7 @@ function init() {
   if (element) element.outerHTML = renderFilters();
 
   componentEl = document.querySelector('[data-component="filters"]');
+  mobileFilterCount = document.querySelector('[data-js="mobile-filter-count"]');
   filterCountEls = componentEl.querySelectorAll('[data-js="filter-count"]');
   activeFiltersEl = componentEl.querySelector('[data-component="active-filters"]');
   priceFilterForm = componentEl.querySelector('[data-js="price-filter"]');

--- a/src/components/product-filters/product-filters.scss
+++ b/src/components/product-filters/product-filters.scss
@@ -1,18 +1,18 @@
 @import '../../scss/mixins';
+@import '../../scss/variables';
 
 .product-filters {
   @include component-panel;
 
-  .heading {
-    padding: 0 24px;
+  .modal & {
+    box-shadow: none;
   }
 
   .skip-link {
-    margin: 0 24px;
+    vertical-align: middle;
   }
 
   &__filter-count {
-    padding: 0 24px;
     font-size: $font-sm;
   }
 
@@ -23,12 +23,6 @@
       border-style: solid;
       border-width: 1px 0 0;
       margin: 0;
-    }
-
-    &__options {
-      padding: 8px 24px;
-      margin: 0;
-      border-top: 1px solid $grey;
     }
 
     &__toggle {
@@ -49,12 +43,66 @@
       }
     }
   }
+
+  .checkbox {
+    &__label {
+      display: flex;
+
+      @media only screen and (max-width: $filters-collapse) {
+        &:not(:last-of-type) {
+          border-bottom: 1px solid $grey;
+          padding-bottom: 8px;
+        }
+      }
+    }
+
+  }
+
+  &__header {
+    padding: 0 24px 16px;
+  }
+
+  &__footer {
+    display: flex;
+    padding: 0 24px;
+
+    @media only screen and (min-width: $filters-collapse) {
+      padding-bottom: 24px;
+    }
+  }
+
+  &__accordion {
+    border-bottom: 1px solid $grey;
+    margin-bottom: 16px;
+  }
+
+  .btn {
+    &+.skip-link {
+      margin: 0 0 0 16px;
+
+      @media only screen and (min-width: $filters-collapse) {
+        margin: 16px 20px 0 0;
+      }
+    }
+  }
+}
+
+.filter {
+  &__options {
+    padding: 8px 24px;
+    margin: 0;
+    border-top: 1px solid $grey;
+  }
 }
 
 .price-filter {
 
   &__fieldset {
     display: flex;
+  }
+
+  &__form {
+    padding-bottom: 16px;
   }
 
   &__label {
@@ -79,28 +127,40 @@
   &__submit {
     width: 100%;
     margin-top: 16px;
+    margin-bottom: 8px;
   }
 
   &__clear-btn {
-    margin: 8px 0 16px;
+    margin: 0;
     padding: 0;
     font-size: $font-sm;
   }
 }
 
 .active-filters {
-  padding: 0 24px;
+  padding: 0;
   list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  grid-gap: 8px;
 
   &__clear-btn {
     font-size: $font-sm;
-    margin: 0 0 24px 24px;
     padding: 0;
+    flex: 0 1 auto;
+  }
+
+  &__close-btn {
+    flex: 1;
+    margin-right: 24px;
+
+    @media only screen and (min-width: $filters-collapse) {
+      display: none;
+    }
   }
 }
 
 .active-filter {
-  margin-bottom: 8px;
 
   .icon--close-btn {
     width: 12px;

--- a/src/components/product-grid/_product-grid.scss
+++ b/src/components/product-grid/_product-grid.scss
@@ -1,7 +1,11 @@
 .product-grid {
   &__jump-links {
-    display: flex;
-    justify-content: space-between;
+    display: none;
+
+    @media only screen and (min-width: $filters-collapse) {
+      display: flex;
+      justify-content: space-between;
+    }
   }
 
   &__product-tiles {

--- a/src/components/product-sort/product-sort.hbs
+++ b/src/components/product-sort/product-sort.hbs
@@ -33,4 +33,9 @@
             </select>
         </div>
     </div>
+    <div class="product-sort__footer">
+        <button class="btn product-sort__close-btn" data-js="close-modal" type="button">
+            I’m done
+        </button>
+    </div>
 </section>

--- a/src/components/product-sort/product-sort.scss
+++ b/src/components/product-sort/product-sort.scss
@@ -4,25 +4,62 @@
 .product-sort {
   @include component-panel;
   padding: 24px;
-  &__options{
-    display: flex;
-    justify-content: space-between;
+
+  .modal & {
+    box-shadow: none;
+    padding: 0;
   }
-  &__option{
-    flex: 0 1 33%;
-    &:not(:first-child){
-      margin-left: 24px;
+
+  &__options {
+    padding: 0 24px;
+
+  }
+
+  &__option {
+    margin-bottom: 24px;
+  }
+
+  @media only screen and (min-width: $filters-collapse) {
+    &__options {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(120px, 200px));
+      grid-gap: 24px;
+      justify-content: space-between;
+      padding: 0;
+    }
+
+    &__option {
+      margin-bottom: 0;
     }
   }
+
+  &__footer {
+    border-top: 1px solid $grey;
+    padding: 16px 24px 0;
+
+    @media only screen and (min-width: $filters-collapse) {
+      display: none;
+    }
+  }
+
+  &__close-btn {
+    width: 100%;
+  }
+
+
   .heading {
     display: inline;
     margin-right: 8px;
+
+    .modal & {
+      margin-left: 24px;
+    }
   }
 }
 
 
 .sort {
-  &__showing-count{
+  &__showing-count {
     font-size: $font-sm;
   }
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -51,7 +51,7 @@ export function getRandomSubset(items, length) {
 }
 
 export function getFocusableChildren(node) {
-  var focusableElements = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
+  var focusableElements = ['a[href]', 'area[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', 'button:not([disabled]):not([tabindex="-1"])', 'iframe', 'object', 'embed', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'];
 
   return $$(focusableElements.join(','), node).filter(function (child) {
     return !!(child.offsetWidth || child.offsetHeight || child.getClientRects().length);
@@ -67,7 +67,6 @@ export function $$(selector, context) {
 export function trapTabKey(node, event) {
   var focusableChildren = getFocusableChildren(node);
   var focusedItemIndex = focusableChildren.indexOf(document.activeElement);
-
   if (event.shiftKey && focusedItemIndex === 0) {
     focusableChildren[focusableChildren.length - 1].focus();
     event.preventDefault();

--- a/src/pages/plp/index.html
+++ b/src/pages/plp/index.html
@@ -18,20 +18,6 @@
     <div class="container">
         <section id="content" class="main-content">
             <h1 id="page-title" class="template-heading">Women’s Tops</h1>
-            <div class="mobile-filters">
-                <button class="mobile-filter" type="button" data-modal-show="filters">
-                    Filters (6)
-                    <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use xlink:href="../../assets/sprite.svg#add"></use>
-                    </svg>
-                </button>
-                <button class="mobile-filter" type="button" data-modal-show="sort">
-                    Sort
-                    <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use xlink:href="../../assets/sprite.svg#add"></use>
-                    </svg>
-                </button>
-            </div>
             <div data-template="filters"></div>
             <div data-template="sort"></div>
             <div data-template="grid"></div>

--- a/src/pages/plp/index.html
+++ b/src/pages/plp/index.html
@@ -19,13 +19,13 @@
         <section id="content" class="main-content">
             <h1 id="page-title" class="template-heading">Women’s Tops</h1>
             <div class="mobile-filters">
-                <button class="mobile-filter" type="button" data-modal="filters">
+                <button class="mobile-filter" type="button" data-modal-show="filters">
                     Filters (6)
                     <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
                         <use xlink:href="../../assets/sprite.svg#add"></use>
                     </svg>
                 </button>
-                <button class="mobile-filter" type="button" data-modal="sort">
+                <button class="mobile-filter" type="button" data-modal-show="sort">
                     Sort
                     <svg class="icon icon--add" xmlns:xlink="http://www.w3.org/1999/xlink">
                         <use xlink:href="../../assets/sprite.svg#add"></use>

--- a/src/pages/plp/plp.js
+++ b/src/pages/plp/plp.js
@@ -5,6 +5,7 @@ import * as productSort from '../../components/product-sort/product-sort';
 import * as productGrid from '../../components/product-grid/product-grid';
 import * as pagination from '../../components/pagination/pagination';
 import * as carousel from '../../components/product-carousel/product-carousel';
+import * as modal from '../../components/modal/modal-dynamic';
 import { chunk, getRandomSubset, setPageTitle } from '../../js/utils';
 import * as productDB from '../../js/pouchdb';
 import * as Modal from '../../components/modal/modal';
@@ -33,14 +34,6 @@ import * as Modal from '../../components/modal/modal';
   productGrid.init();
   pagination.init();
   carousel.init();
-
-  // Event Listeners
-  document.addEventListener('update:filters', filterProducts);
-  document.addEventListener('update:sort', sortProducts);
-  document.addEventListener('update:ipp', updateComponents);
-  document.addEventListener('update:pagination', getPage);
-
-  Modal.init('construction-modal');
 
   function getPage(event) {
     let newPage = event.detail.goToPage;
@@ -84,6 +77,18 @@ import * as Modal from '../../components/modal/modal';
       carousel.update(carouselItems);
     });
   }
+
+  function showModal() {
+    modal.init();
+    console.log('%c CLICK ', 'background: hotpink; color: white');
+  }
+
+  // Event Listeners
+  document.addEventListener('update:filters', filterProducts);
+  document.addEventListener('update:sort', sortProducts);
+  document.addEventListener('update:ipp', updateComponents);
+  document.addEventListener('update:pagination', getPage);
+  document.querySelector('[data-modal-show="filters"]').addEventListener('click', showModal);
 
   setPageTitle(['Women', 'Women’s Tops']);
   productDB.init().then(fetchComponentData);

--- a/src/pages/plp/plp.js
+++ b/src/pages/plp/plp.js
@@ -5,7 +5,7 @@ import * as productSort from '../../components/product-sort/product-sort';
 import * as productGrid from '../../components/product-grid/product-grid';
 import * as pagination from '../../components/pagination/pagination';
 import * as carousel from '../../components/product-carousel/product-carousel';
-import * as modal from '../../components/modal/modal-dynamic';
+import * as DynamicModal from '../../components/modal/modal-dynamic';
 import { chunk, getRandomSubset, setPageTitle } from '../../js/utils';
 import * as productDB from '../../js/pouchdb';
 import * as Modal from '../../components/modal/modal';
@@ -34,6 +34,8 @@ import * as Modal from '../../components/modal/modal';
   productGrid.init();
   pagination.init();
   carousel.init();
+
+  Modal.init('construction-modal');
 
   function getPage(event) {
     let newPage = event.detail.goToPage;
@@ -78,9 +80,12 @@ import * as Modal from '../../components/modal/modal';
     });
   }
 
-  function showModal() {
-    modal.init();
-    console.log('%c CLICK ', 'background: hotpink; color: white');
+  function loadModal(event) {
+    const componentName = event.currentTarget.dataset.modalLoad;
+    DynamicModal.init(
+      `[data-component="${componentName}"]`,
+      `modal-${componentName}`
+    );
   }
 
   // Event Listeners
@@ -88,7 +93,8 @@ import * as Modal from '../../components/modal/modal';
   document.addEventListener('update:sort', sortProducts);
   document.addEventListener('update:ipp', updateComponents);
   document.addEventListener('update:pagination', getPage);
-  document.querySelector('[data-modal-show="filters"]').addEventListener('click', showModal);
+  const dynamicModals = document.querySelectorAll('[data-modal-load]');
+  dynamicModals.forEach((modalTrigger) => modalTrigger.addEventListener('click', loadModal));
 
   setPageTitle(['Women', 'Women’s Tops']);
   productDB.init().then(fetchComponentData);

--- a/src/pages/plp/plp.scss
+++ b/src/pages/plp/plp.scss
@@ -6,6 +6,7 @@
     padding-bottom: 72px;
     border-bottom: 1px solid $grey;
     margin-bottom: 24px;
+
     @media only screen and (min-width: $filters-collapse) {
       display: grid;
       grid-column-gap: 24px;
@@ -24,21 +25,33 @@
       padding-right: 50px;
     }
   }
+
   .template-heading {
     grid-column: 1 / span 2;
   }
+
   .product-filters {
     display: none;
     grid-row: 2 / 6;
     align-self: start;
   }
+
+  .modal .product-filters {
+    display: block;
+  }
+
   .product-grid {
     margin-bottom: 40px;
   }
+
   .product-sort {
     display: none;
     grid-column: 2 / span 1;
-    margin-bottom: 48px;
+    margin-bottom: 8px;
+  }
+
+  .modal .product-sort {
+    display: block;
   }
 
   .mobile-filters {
@@ -48,6 +61,7 @@
     @include soft-shadow;
     display: flex;
   }
+
   .mobile-filter {
     flex: 1;
     padding: 16px;
@@ -57,22 +71,30 @@
     font-size: $font-md;
     font-weight: bold;
     display: flex;
+
     &:not(:first-child) {
       border-left: 1px solid $medium-grey;
     }
+
     .icon {
       margin-left: auto;
       width: 24px;
       height: 24px;
     }
   }
+
   @media only screen and (min-width: $filters-collapse) {
     .mobile-filters {
       display: none;
     }
+
     .product-filters,
     .product-sort {
       display: block;
+    }
+
+    .product-sort {
+      margin-bottom: 48px;
     }
   }
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -3,7 +3,6 @@ import footerTemplate from './components/footer/footer.hbs';
 import constructionModalTemplate from './components/modal/construction-modal.hbs';
 import * as MiniCart from './components/mini-cart/mini-cart';
 import * as GlobalNav from './components/header/global-navigation';
-import * as Modal from './components/modal/modal';
 import { enableSkipLinks } from './js/utils';
 
 // Global templating

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -24,5 +24,4 @@ if (constructionModalDOM) constructionModalDOM.outerHTML = constructionModalTemp
 // Global components
 GlobalNav.init();
 MiniCart.init();
-
 enableSkipLinks();

--- a/src/scss/_helpers.scss
+++ b/src/scss/_helpers.scss
@@ -1,31 +1,35 @@
 @import './variables';
+
 /* =============================================== HELPERS */
 .clearfix:after {
-	visibility: hidden;
-	display: block;
-	content: "";
-	clear: both;
-	height: 0;
+  visibility: hidden;
+  display: block;
+  content: "";
+  clear: both;
+  height: 0;
 }
 
 .element-invisible {
-	position: absolute !important;
-	height: 1px; width: 1px; 
-	overflow: hidden;
-	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-	clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px);
+  /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
 }
 
 .divider {
-	margin: 23px 0;
-	border: 0;
-	height: 1px;
-	background: $grey;
+  margin: 23px 0;
+  border: 0;
+  height: 1px;
+  background: $grey;
 }
 
 .rotate-90 {
   transform: rotate(90deg);
 }
+
 .rotate-180 {
   transform: rotate(180deg);
 }
@@ -35,40 +39,47 @@
 }
 
 .skip-link {
-  color: transparent;
-  font-size: 12px;
-  height: 1px;
-  width: 1px;
-  position: absolute;
-  overflow: hidden;
-  left: -9999px;
+  // position: absolute;
+// width: 1px;
+// height: 1px;
+// margin: -1px;
+// padding: 0;
+// overflow: hidden;
+// clip: rect(0, 0, 0, 0);
+// border: 0;
+
   &:focus {
-    color: $pure-black;
-    height: auto;
-    width: auto;
     position: static;
-    display: inline-block;
-    margin: 10px 0;
-	}
-	.product-sort &{
-		margin-bottom: 0;
-	}
-	.product-grid__jump-links &{
-		&:focus{
-			margin-top: -32px;
-		}
+    width: auto;
+    height: auto;
+    margin: 0;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    overflow: visible;
+    clip: auto;
   }
-  .carousel-wrapper &{
+
+  .product-sort & {
+    margin-bottom: 0;
+  }
+
+  .product-grid__jump-links & {
+    &:focus {
+      margin-top: -32px;
+    }
+  }
+
+  .carousel-wrapper & {
     vertical-align: bottom;
   }
 }
 
 .visibly-hidden {
-	visibility: hidden;
-	height: 0;
-	width: 0;
-	position: absolute;
-	left: -9999;
+  visibility: hidden;
+  height: 0;
+  width: 0;
+  position: absolute;
+  left: -9999;
 }
 
 .sr-only {
@@ -82,7 +93,8 @@
   border: 0;
 }
 
-.sr-only-focusable:active, .sr-only-focusable:focus {
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
   position: static;
   width: auto;
   height: auto;
@@ -91,6 +103,6 @@
   clip: auto;
 }
 
-.hidden{
-	display: none;
+.hidden {
+  display: none;
 }

--- a/src/scss/_helpers.scss
+++ b/src/scss/_helpers.scss
@@ -39,24 +39,21 @@
 }
 
 .skip-link {
-  // position: absolute;
-// width: 1px;
-// height: 1px;
-// margin: -1px;
-// padding: 0;
-// overflow: hidden;
-// clip: rect(0, 0, 0, 0);
-// border: 0;
+  color: transparent;
+  font-size: 12px;
+  height: 1px;
+  width: 1px;
+  position: absolute;
+  overflow: hidden;
+  left: -9999px;
 
   &:focus {
-    position: static;
-    width: auto;
+    color: $pure-black;
     height: auto;
-    margin: 0;
-    margin-top: 0px;
-    margin-bottom: 0px;
-    overflow: visible;
-    clip: auto;
+    width: auto;
+    position: static;
+    display: inline-block;
+    margin: 10px 0;
   }
 
   .product-sort & {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -53,6 +53,10 @@ button {
   font-size: $font-lg;
   font-weight: bold;
   margin-top: 2.4rem;
+
+  .modal & {
+    margin-top: 0;
+  }
 }
 
 button,
@@ -92,6 +96,7 @@ select::-moz-focus-inner {
 @import "./components/footer/footer";
 @import "./components/header/global-navigation";
 @import "./components/mini-cart/mini-cart";
+@import "./components/accordion/accordion";
 
 @import "./components/product-filters/product-filters";
 @import "./components/product-grid/product-grid";
@@ -103,7 +108,6 @@ select::-moz-focus-inner {
 @import "./components/product-details/product-details";
 @import "./components/gallery/gallery";
 
-@import "./components/accordion/accordion";
 @import "./components/modal/_modal.scss";
 @import "./components/product-details-accordion/product-details-accordion";
 @import "./components/size-chart/size-chart";


### PR DESCRIPTION
Issue: #123 

- Add mobile filter/sort overlays
- Apply general fixes to mobile modals
- Add visible label to search button on mobile

There's a fair amount of duplicated effort between the modal-dynamic.js and modal.js files now, but the original modal.js didn't quite meet all of my needs and I didn't want to cause a lot of regression or refactoring. The two approaches can maybe be consolidated now that we have an idea of the different use-cases we have for modals and overlays.

Some things I tackled with the new code:
- wrapping every immediate child of body in a dynamic div that's set to aria-hidden, and unwrapping on close
- dynamically inserting modal at foot of body (so we don't need to leave a placeholder)
- adding a click to close feature to modal backdrop
- prevent page scroll while modal is open
- close modal when user exits mobile breakpoint with open filter.
