### PR TITLE
Fix for issue #178

### DIFF
--- a/src/components/product-filters/product-filters.hbs
+++ b/src/components/product-filters/product-filters.hbs
@@ -92,16 +92,20 @@
                 <p class="error-summary hidden" id="errorSummaryPriceFilters" role="alert">You have <span></span> in your price range.</p>
                 <fieldset class="price-filter__fieldset">
                     <legend id="priceLegend" class="visibly-hidden">Filter by Price</legend>
-                    <label for="priceFrom" class="price-filter__label">
-                        <span class="sr-only">Price </span>From
-                        <span class="error-msg hidden" id="priceFromErrorMsg">Enter a number between 0 and 999.</span>
-                        <input type="text" name="priceFrom" id="priceFrom" class="price-filter__input" aria-describedby="priceFromErrorMsg">
-                    </label>
-                    <label for="priceTo" class="price-filter__label">
-                        <span class="sr-only">Price </span>To 
-                        <span class="error-msg hidden" id="priceToErrorMsg">Enter a number between 0 and 999.</span>
-                        <input type="text" name="priceTo" id="priceTo" class="price-filter__input" aria-describedby="priceToErrorMsg">
-                    </label>
+                    <div class="price-filter__field-container">
+                        <label for="priceFrom" class="price-filter__label">
+                            <span class="sr-only">Price </span>From
+                            <input type="text" name="priceFrom" id="priceFrom" class="price-filter__input" aria-describedby="priceFromErrorMsg">
+                        </label>
+                        <span class="error-msg priceFrom hidden" data-field="priceFrom" id="priceFromErrorMsg">Enter a number between 0 and 999.</span>
+                    </div>
+                    <div class="price-filter__field-container">
+                        <label for="priceTo" class="price-filter__label">
+                            <span class="sr-only">Price </span>To 
+                            <input type="text" name="priceTo" id="priceTo" class="price-filter__input" aria-describedby="priceToErrorMsg">
+                        </label>
+                        <span class="error-msg priceTo hidden" data-field="priceTo" id="priceToErrorMsg">Enter a number between 0 and 999.</span>
+                    </div>
                 </fieldset>
                 <button type="submit" class="price-filter__submit btn btn--outline-black">Update Range</button>
                 <button class="btn btn--link price-filter__clear-btn" type="button" data-js="price-range-clear">

--- a/src/components/product-filters/product-filters.hbs
+++ b/src/components/product-filters/product-filters.hbs
@@ -89,14 +89,18 @@
             <form data-js="price-filter" class="price-filter__form accordion__panel filter__options">
                 <input type="hidden" name="priceFilterFrom" id="priceFilterFrom" value="">
                 <input type="hidden" name="priceFilterTo" id="priceFilterTo" value="">
-                <p class="error-summary hidden" id="errorSummaryPriceFilters" role="alert"></p>
+                <p class="error-summary hidden" id="errorSummaryPriceFilters" role="alert">You have <span></span> in your price range.</p>
                 <fieldset class="price-filter__fieldset">
                     <legend id="priceLegend" class="visibly-hidden">Filter by Price</legend>
                     <label for="priceFrom" class="price-filter__label">
-                        <span class="sr-only">Price </span>From <input type="text" name="priceFrom" id="priceFrom" class="price-filter__input">
+                        <span class="sr-only">Price </span>From
+                        <span class="error-msg hidden" id="priceFromErrorMsg">Enter a number between 0 and 999.</span>
+                        <input type="text" name="priceFrom" id="priceFrom" class="price-filter__input" aria-describedby="priceFromErrorMsg">
                     </label>
                     <label for="priceTo" class="price-filter__label">
-                        <span class="sr-only">Price </span>To <input type="text" name="priceTo" id="priceTo" class="price-filter__input">
+                        <span class="sr-only">Price </span>To 
+                        <span class="error-msg hidden" id="priceToErrorMsg">Enter a number between 0 and 999.</span>
+                        <input type="text" name="priceTo" id="priceTo" class="price-filter__input" aria-describedby="priceToErrorMsg">
                     </label>
                 </fieldset>
                 <button type="submit" class="price-filter__submit btn btn--outline-black">Update Range</button>

--- a/src/components/product-filters/product-filters.hbs
+++ b/src/components/product-filters/product-filters.hbs
@@ -89,6 +89,7 @@
             <form data-js="price-filter" class="price-filter__form accordion__panel filter__options">
                 <input type="hidden" name="priceFilterFrom" id="priceFilterFrom" value="">
                 <input type="hidden" name="priceFilterTo" id="priceFilterTo" value="">
+                <p class="error-summary hidden" id="errorSummaryPriceFilters" role="alert"></p>
                 <fieldset class="price-filter__fieldset">
                     <legend id="priceLegend" class="visibly-hidden">Filter by Price</legend>
                     <label for="priceFrom" class="price-filter__label">

--- a/src/components/product-filters/product-filters.js
+++ b/src/components/product-filters/product-filters.js
@@ -126,12 +126,13 @@ function validatePriceFields(event) {
 
   const fields = Array.from(priceFilterForm.querySelectorAll('.price-filter__input'));
   fields.forEach(function(input) {
+    let inputId = input.getAttribute('id');
     if (input.value.match(nonCurrencyChars) || input.value < minPrice || input.value > maxPrice) {
       input.classList.add('error');
-      input.previousElementSibling.classList.remove('hidden');
+      priceFilterForm.querySelector(`[data-field=${inputId}]`).classList.remove('hidden');
     } else {
       input.classList.remove('error');
-      input.previousElementSibling.classList.add('hidden');
+      priceFilterForm.querySelector(`[data-field=${inputId}]`).classList.add('hidden');
     }
   });
 

--- a/src/components/product-filters/product-filters.js
+++ b/src/components/product-filters/product-filters.js
@@ -126,19 +126,19 @@ function validatePriceFields(event) {
 
   const fields = Array.from(priceFilterForm.querySelectorAll('.price-filter__input'));
   fields.forEach(function(input) {
-    if (input.value.match(nonCurrencyChars)) {
+    if (input.value.match(nonCurrencyChars) || input.value < minPrice || input.value > maxPrice) {
       input.classList.add('error');
-      input.setAttribute('aria-describedby', errorSummary.getAttribute('id'));
+      input.previousElementSibling.classList.remove('hidden');
     } else {
       input.classList.remove('error');
-      input.removeAttribute('aria-describedby');
+      input.previousElementSibling.classList.add('hidden');
     }
   });
 
   numErrors = document.getElementsByClassName('price-filter__input error').length;
   if (numErrors > 0) {
     errorText = numErrors === 1 ? 'error' : 'errors';
-    errorSummary.innerText = `You have ${numErrors} ${errorText} in your price range.`;
+    errorSummary.querySelector('span').innerText = `${numErrors} ${errorText}`;
     errorSummary.classList.remove('hidden');
     document.getElementsByClassName("price-filter__input error")[0].focus();
     validated = false;
@@ -153,7 +153,7 @@ function clearErrorState() {
   const fields = Array.from(priceFilterForm.querySelectorAll('.price-filter__input'));
   fields.forEach(function(input) {
     input.classList.remove('error');
-    input.removeAttribute('aria-describedby');
+    input.previousElementSibling.classList.add('hidden');
   });
   document.querySelector('.error-summary').classList.add('hidden');
 }

--- a/src/components/product-filters/product-filters.js
+++ b/src/components/product-filters/product-filters.js
@@ -13,6 +13,8 @@ let priceToField;
 let priceFilterFrom;
 let priceFilterTo;
 const nonCurrencyChars = /[^0-9.-]+/g;
+const minPrice = 0;
+const maxPrice = 999;
 
 // Private functions
 function pushFilterUpdateEvent() {
@@ -89,8 +91,13 @@ function onActiveFilterClick(event) {
 function onPriceFilterSubmit(event) {
   event.preventDefault();
   priceFilterFrom.value = priceFromField.value.replace(nonCurrencyChars, '');
+  priceFilterFrom.value = priceFilterFrom.value === '' ? minPrice : priceFilterFrom.value;
   priceFilterTo.value = priceToField.value.replace(nonCurrencyChars, '');
-  updateFilters();
+  priceFilterTo.value = priceFilterTo.value === '' ? maxPrice : priceFilterTo.value;
+  
+  if (validatePriceFields()) {
+    updateFilters();
+  }
 }
 
 function onPriceFilterClear() {
@@ -98,6 +105,7 @@ function onPriceFilterClear() {
   priceFilterTo.value = '';
   priceFromField.value = '';
   priceToField.value = '';
+  clearErrorState();
   updateFilters();
 }
 
@@ -107,6 +115,47 @@ function clearFilters() {
     filter.checked = false;
   });
   updateFilters();
+}
+
+function validatePriceFields(event) {
+  const submitBtn = document.querySelector('.price-filter__submit');
+  const errorSummary = document.querySelector('.error-summary');
+  let validated = true;
+  let errorText;
+  let numErrors;
+
+  const fields = Array.from(priceFilterForm.querySelectorAll('.price-filter__input'));
+  fields.forEach(function(input) {
+    if (input.value.match(nonCurrencyChars)) {
+      input.classList.add('error');
+      input.setAttribute('aria-describedby', errorSummary.getAttribute('id'));
+    } else {
+      input.classList.remove('error');
+      input.removeAttribute('aria-describedby');
+    }
+  });
+
+  numErrors = document.getElementsByClassName('price-filter__input error').length;
+  if (numErrors > 0) {
+    errorText = numErrors === 1 ? 'error' : 'errors';
+    errorSummary.innerText = `You have ${numErrors} ${errorText} in your price range.`;
+    errorSummary.classList.remove('hidden');
+    document.getElementsByClassName("price-filter__input error")[0].focus();
+    validated = false;
+  } else {
+    errorSummary.classList.add('hidden');
+    validated = true;
+  }
+  return validated;
+}
+
+function clearErrorState() {
+  const fields = Array.from(priceFilterForm.querySelectorAll('.price-filter__input'));
+  fields.forEach(function(input) {
+    input.classList.remove('error');
+    input.removeAttribute('aria-describedby');
+  });
+  document.querySelector('.error-summary').classList.add('hidden');
 }
 
 // Public functions

--- a/src/components/product-filters/product-filters.scss
+++ b/src/components/product-filters/product-filters.scss
@@ -105,13 +105,15 @@
     padding-bottom: 16px;
   }
 
-  &__label {
-    font-size: $font-xs;
-    flex: 1 1 auto;
-
+  &__field-container {
     &:first-of-type {
       margin-right: 8px;
     }
+  }
+
+  &__label {
+    font-size: $font-xs;
+    flex: 1 1 auto;
   }
 
   &__input {

--- a/src/components/product-filters/product-filters.scss
+++ b/src/components/product-filters/product-filters.scss
@@ -187,3 +187,11 @@
   color: $error-red;
   font-size: $font-xs;
 }
+
+.error-msg {
+  color: $error-red;
+  font-size: $font-xs;
+  &:not(.hidden) {
+    display: inline-block;
+  }
+}

--- a/src/components/product-filters/product-filters.scss
+++ b/src/components/product-filters/product-filters.scss
@@ -182,3 +182,8 @@
     align-items: center;
   }
 }
+
+.error-summary {
+  color: $error-red;
+  font-size: $font-xs;
+}

--- a/src/scss/_inputs.scss
+++ b/src/scss/_inputs.scss
@@ -129,3 +129,9 @@ select {
   font-size: $font-sm;
   font-weight: bold;
 }
+
+input[type=text] {
+  &.error {
+    border: 1px solid $error-red
+  }
+}


### PR DESCRIPTION
Added form validation for price filters.

@brianelton, @aevanson ,
Validation is done on submit of the form, and not on keyup or blur as that would mean the state would be changing a lot which would be confusing for people using screen readers. Also, you wouldn't be able to tab to another element while in an error state because the focus would be set to the first <input> with an error.

I set the default range of 0-999 if the fields are blank, but I didn't limit the inputs to a max of 999. I can do that for sure, which would mean specifying that in the error message as well. Let me know.