### PR TITLE
bugfix/204-sgv-rootpath-2

### DIFF
--- a/src/components/mini-cart/_mini-cart.scss
+++ b/src/components/mini-cart/_mini-cart.scss
@@ -162,7 +162,7 @@
   }
 
   &__image {
-    max-width: 100%;
+    max-width: 45%;
     height: auto;
     flex: 0 0 70px;
     margin-right: 16px;


### PR DESCRIPTION
Tweaked the .mini-cart__image class to 45% width to keep the mini cart item details / layout tight
original issue: https://github.com/PublicisSapient/accessible-ecommerce-demo/issues/204
original PR: https://github.com/PublicisSapient/accessible-ecommerce-demo/pull/216