### PR TITLE
Fix ecommerce line breaks

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -19,7 +19,7 @@
     <section class="hero">
         <div class="container">
             <h1 class="hero__headline">About Us</h1>
-            <p class="hero__subhead">An iterative, interactive prototype of an e-commerce storefront that explores concepts in designing and developing for the web, considering accessibility first.</p>
+            <p class="hero__subhead">An iterative, interactive prototype of an e&#8209;commerce storefront that explores concepts in designing and developing for the web, considering accessibility first.</p>
         </div>
     </section>
     <div class="about-us__content container">
@@ -35,11 +35,11 @@
         <main class="about-us__main">
             <section class="about-us__section">
                 <h2 id="our-story" class="about-us__section-title">Our Story</h2>
-                <p>The Accessible eStore is an iterative, interactive prototype of an e-commerce storefront. It explores concepts in designing and developing for the web considering accessibility first. Web accessibility is more of a journey than a destination. In that spirit, this experience will evolve based on our continued learning and user feedback.</p>
-                <p>The web needs more examples of accessible and usable design and development. We tried to make our store's typical e-commerce components keyboard and screen-reader accessible. We hope our work starts a conversation. We want it to lead to action that accelerates the creation of accessible and usable web experiences around the world. We want to enable everyone to fully participate in online activities and engage with their communities.</p>
+                <p>The Accessible eStore is an iterative, interactive prototype of an e&#8209;commerce storefront. It explores concepts in designing and developing for the web considering accessibility first. Web accessibility is more of a journey than a destination. In that spirit, this experience will evolve based on our continued learning and user feedback.</p>
+                <p>The web needs more examples of accessible and usable design and development. We tried to make our store's typical e&#8209;commerce components keyboard and screen-reader accessible. We hope our work starts a conversation. We want it to lead to action that accelerates the creation of accessible and usable web experiences around the world. We want to enable everyone to fully participate in online activities and engage with their communities.</p>
                 <p>Creating our store was a tremendous undertaking. We began by providing screen reader training to our creative and technical teams. This is critical. You wouldn't ask someone who had never ridden a bike to design or build a bike. But every day designers and developers are asked to stretch in exactly this way. The vast majority of designers and developers are sighted mouse-pointer users. And yet they are tasked with creating experiences that will work with a keyboard and assistive technology. We wanted to teach people to ride bicycles before we asked them to design or build them.</p>
                 <p>We collaborated with and gained insights from our non-sighted colleagues. They helped us understand their major pain points in websites that are designed for people who can use a mouse.</p>
-                <p>We then unrolled a curriculum that we call the “Accessibility Deep Dive” sessions. Each session focused on accessibility best practices for a common e-commerce website component. For example, the global navigation menu, the product listing grid, filters, and sorting mechanisms. We considered how each of these should work for people using assistive devices. </p>
+                <p>We then unrolled a curriculum that we call the “Accessibility Deep Dive” sessions. Each session focused on accessibility best practices for a common e&#8209;commerce website component. For example, the global navigation menu, the product listing grid, filters, and sorting mechanisms. We considered how each of these should work for people using assistive devices. </p>
                 <p>After everyone had enough context, we began creating the store one component at a time, via a series of hackathons. In each hackathon, we paired 2 user experience designers with 2 front end developers. Each team designed and built their assigned component or set of components within 4 hours. Post-hackathon, a front-end developer compiled the components into a page, and we engaged a visual designer to help us with polish.</p>
                 <p>Truly inclusive experiences require both thoughtful design and execution. We need to grow these skills in our creative and technical teams to finally arrive at a web that is truly accessible. The demand for this skillset is growing, but web accessibility compliance strategies are not taught in most schools. </p>
                 <p>We wanted to help enable the next generation of designers and developers to create accessible experiences. Creating the store helped our internal teams. We hope that by posting our work in progress online that we have created a resource for the world to use in order to explore this important topic.</p>
@@ -106,11 +106,11 @@
             <section class="about-us__section">
                 <h2 id="unfulfilled-promise" class="about-us__section-title">The Unfulfilled Promise of the Internet</h2>
                 <h3 class="about-us__subsection-title">Introduction</h3>
-                <p>From the late 1990s onward, the internet gradually became part of our lives, until in 2018, about 4 billion people used “the Web”. With more and more people using the internet, physical modes of content were steadily replaced by electronic modes of content. A big part of the shift was that commerce at physical locations has been replaced or augmented by e-commerce storefronts. This shift had the potential to remove many of the barriers to communication that existed for people with disabilities in the physical world, but only if websites were designed and developed accessibly. </p>
-                <p>Over the last 25 years, there have been many technological advancements in the internet space. Human ingenuity created search engines like Google, a variety of payment systems like Paypal, Apple Pay, and bitcoin, and e-commerce giants who have created a market where e-commerce comprised more than 10% of US sales in 2017. </p>
-                <p>Yet our studies show that there are still no e-commerce sites that are completely accessible and usable.</p>
+                <p>From the late 1990s onward, the internet gradually became part of our lives, until in 2018, about 4 billion people used “the Web”. With more and more people using the internet, physical modes of content were steadily replaced by electronic modes of content. A big part of the shift was that commerce at physical locations has been replaced or augmented by e&#8209;commerce storefronts. This shift had the potential to remove many of the barriers to communication that existed for people with disabilities in the physical world, but only if websites were designed and developed accessibly. </p>
+                <p>Over the last 25 years, there have been many technological advancements in the internet space. Human ingenuity created search engines like Google, a variety of payment systems like Paypal, Apple Pay, and bitcoin, and e&#8209;commerce giants who have created a market where e&#8209;commerce comprised more than 10% of US sales in 2017. </p>
+                <p>Yet our studies show that there are still no e&#8209;commerce sites that are completely accessible and usable.</p>
                 <h3 class="about-us__subsection-title">Identifying the problem</h3>
-                <p>For the past several years, we have audited a selection of e-commerce retailers for accessibility. We used automated tools and manual keyboard and screen reader tests to assess compliance. </p>
+                <p>For the past several years, we have audited a selection of e&#8209;commerce retailers for accessibility. We used automated tools and manual keyboard and screen reader tests to assess compliance. </p>
                 <p>Our results indicate that 60% of these experiences include significant accessibility barriers. These barriers would likely prevent users of assistive technologies from making a purchase online. Common issues include: </p>
                 <ul>
                     <li>navigation menus that are difficult to use,</li>
@@ -121,9 +121,9 @@
                     <li>coding errors that result in an excessive amounts of extra tab stops. </li>
                 </ul>
                 <p>User flows employing search were more accessible than those employing browse techniques. For example, a mouse user could browse for curtains and then filter by color and length. However, an assistive technology user is more likely to achieve success by searching for all of the criteria (e.g. “yellow sheer curtains”). This does not present an equivalent experience.</p>
-                <p>Results have been improving year over year. But this exercise shows that accessible experiences are still trailing far behind traditional experiences, even when it comes to the world’s most high performing e-commerce websites. </p>
+                <p>Results have been improving year over year. But this exercise shows that accessible experiences are still trailing far behind traditional experiences, even when it comes to the world’s most high performing e&#8209;commerce websites. </p>
                 <a class="btn" href="#medium-study">See detailed results for this year on Medium</a>
-                <p>Most people today can hardly conceive of life without the Internet, or without e-commerce. But a majority of online retail stores are effectively CLOSED for this population of 770 million people in the world. This is a huge market that businesses should want to tap into, and it’s the right thing to do. We have the tools. The knowledge is out there.</p>
+                <p>Most people today can hardly conceive of life without the Internet, or without e&#8209;commerce. But a majority of online retail stores are effectively CLOSED for this population of 770 million people in the world. This is a huge market that businesses should want to tap into, and it’s the right thing to do. We have the tools. The knowledge is out there.</p>
             </section>
             <section class="about-us__section">
                 <h2 id="what-the-demo-is" class="about-us__section-title">What our demo is, and what it is not</h2>
@@ -131,7 +131,7 @@
                     <li class="what-the-demo__item"><strong>It is intended to be fully keyboard navigable and screen reader-friendly in its current state.</strong> Navigate with your tab key to discover hidden wayfinding cues, and note how we tried to provide screen reader users with the appropriate amount of context and information as they navigated through the site. Let us know if you experience any issues or have suggestions.</li>
                     <li class="what-the-demo__item"><strong>It is not fully designed.</strong> Think of it as an interactive desktop wireframe right now. We are working out all of the interactions first, then applying an eye-catching design later.</li>
                     <li class="what-the-demo__item"><strong>It is not fully functional</strong> at the moment. For example, right now you can’t add an item to your cart. We plan to make that work shortly. This is as far as we got for Global Accessibility Awareness Day.</li>
-                    <li class="what-the-demo__item"><strong>It is not representative of today’s best coding standards – yet.</strong> This code came out of multiple hackathon sessions. The point of the demo today is to showcase how an accessible e-commerce website should feel and behave. We will clean up the code later.</li>
+                    <li class="what-the-demo__item"><strong>It is not representative of today’s best coding standards – yet.</strong> This code came out of multiple hackathon sessions. The point of the demo today is to showcase how an accessible e&#8209;commerce website should feel and behave. We will clean up the code later.</li>
                     <li class="what-the-demo__item"><strong>It is not perfect.</strong> We didn’t want to waste time trying to make it perfect before getting it out there. The danger would be that it would never be perfect enough. Edward de Bono said it best: <strong>“An idea that is developed and put into action is more important than an idea that exists only as an idea.”</strong></li>
                 </ul>
                 <p>To start using the prototype, navigate to the "Women" section using the global navigation menu, or <a href="https://publicissapient.github.io/accessible-ecommerce-demo/plp/index.html">follow this link to the Women's section</a>.</p>
@@ -156,7 +156,7 @@
     <script>
 
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
+        function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());
 
         gtag('config', 'UA-140213591-1');

--- a/src/scss/about-us.scss
+++ b/src/scss/about-us.scss
@@ -112,14 +112,17 @@
       margin-top: 0;
     }
   }
+
   &__team-list {
     li {
-      float:left;
+      float: left;
       width: 50%;
+      padding-right: 30px;
     }
   }
+
   @media screen and (max-width: $mobile) {
-    &__team-list {  
+    &__team-list {
       li {
         float: none;
         width: 100%;


### PR DESCRIPTION
- In Safari, e-commerce is breaking onto two lines. All hyphens in
e-commerce have been replaced with the non-breaking hyphen HTML entity
- Small fixup for long team titles that were mashing into the right
column