### PR TITLE
chore(dependencies): security update on outdated npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1127,9 +1127,9 @@
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -1137,17 +1137,17 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
 					"dev": true
 				}
 			}
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"agent-base": {
@@ -2933,15 +2933,15 @@
 			}
 		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
-			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -2974,19 +2974,6 @@
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
 				"whatwg-url": "^7.0.0"
-			},
-			"dependencies": {
-				"whatwg-url": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
-					"dev": true,
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
-					}
-				}
 			}
 		},
 		"date-now": {
@@ -3352,9 +3339,9 @@
 			}
 		},
 		"ecstatic": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.1.tgz",
-			"integrity": "sha512-/rrctvxZ78HMI/tPIsqdvFKHHscxR3IJuKrZI2ZoUgkt2SiufyLFBmcco+aqQBIu6P1qBsUNG3drAAGLx80vTQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+			"integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
 			"dev": true,
 			"requires": {
 				"he": "^1.1.1",
@@ -4108,7 +4095,8 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4132,13 +4120,15 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4155,19 +4145,22 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4298,7 +4291,8 @@
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4312,6 +4306,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4328,6 +4323,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4336,13 +4332,15 @@
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4363,6 +4361,7 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4451,7 +4450,8 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4465,6 +4465,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4560,7 +4561,8 @@
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4602,6 +4604,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4623,6 +4626,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4671,13 +4675,15 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -4901,9 +4907,9 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -5098,19 +5104,123 @@
 			"dev": true
 		},
 		"htmlnano": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.3.tgz",
-			"integrity": "sha512-iS6T3J5gk2wInodbtMUyAU8sLYJOhuWDnIEd8lFRoHTypVGgawPHFEx2ZIK/XTErtDfwHBsrXeCwHAP8bdoSWw==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.4.tgz",
+			"integrity": "sha512-wsg7+Hjyi1gHpMUixkeOjeRUNhBBTnEDB//kzvVHR+LUK4p+/31DAyE+pEACT0SQk3W0KE7Xdylk9+uNxdHXLg==",
 			"dev": true,
 			"requires": {
-				"cssnano": "^4.1.9",
-				"normalize-html-whitespace": "^0.2.0",
+				"cssnano": "^4.1.10",
+				"normalize-html-whitespace": "^1.0.0",
 				"object-assign": "^4.0.1",
-				"posthtml": "^0.11.3",
-				"posthtml-render": "^1.1.4",
-				"svgo": "^1.0.5",
-				"terser": "^3.16.1",
-				"uncss": "^0.16.2"
+				"posthtml": "^0.11.4",
+				"posthtml-render": "^1.1.5",
+				"svgo": "^1.2.2",
+				"terser": "^4.1.2",
+				"uncss": "^0.17.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+					"dev": true
+				},
+				"css-tree": {
+					"version": "1.0.0-alpha.33",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+					"integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+					"dev": true,
+					"requires": {
+						"mdn-data": "2.0.4",
+						"source-map": "^0.5.3"
+					}
+				},
+				"mdn-data": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+					"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+					"dev": true
+				},
+				"posthtml": {
+					"version": "0.11.4",
+					"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.4.tgz",
+					"integrity": "sha512-ezlzBkoPoRgh0jkmT1dsM8eT+lr2azyZ546kbda8oHnVnzvyaB3Ywo6UxUz8wPSOkFAAflCxZJhvvpQH1F6qcA==",
+					"dev": true,
+					"requires": {
+						"posthtml-parser": "^0.4.1",
+						"posthtml-render": "^1.1.5"
+					}
+				},
+				"posthtml-render": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.5.tgz",
+					"integrity": "sha512-yvt54j0zCBHQVEFAuR+yHld8CZrCa/E1Z/OcFNCV1IEWTLVxT8O7nYnM4IIw1CD4r8kaRd3lc42+0lgCKgm87w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.13",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+					"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
+					}
+				},
+				"svgo": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+					"integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.1",
+						"coa": "^2.0.2",
+						"css-select": "^2.0.0",
+						"css-select-base-adapter": "^0.1.1",
+						"css-tree": "1.0.0-alpha.33",
+						"csso": "^3.5.1",
+						"js-yaml": "^3.13.1",
+						"mkdirp": "~0.5.1",
+						"object.values": "^1.1.0",
+						"sax": "~1.2.4",
+						"stable": "^0.1.8",
+						"unquote": "~1.1.1",
+						"util.promisify": "~1.0.0"
+					}
+				},
+				"terser": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
+					"integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
+					}
+				}
 			}
 		},
 		"htmlparser2": {
@@ -5346,6 +5456,12 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
+		},
+		"ip-regex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+			"dev": true
 		},
 		"is": {
 			"version": "3.3.0",
@@ -5764,9 +5880,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -5788,37 +5904,78 @@
 			"dev": true
 		},
 		"jsdom": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.1.1.tgz",
+			"integrity": "sha512-cQZRBB33arrDAeCrAEWn1U3SvrvC8XysBua9Oqg1yWrsY/gYcusloJC3RZJXuY5eehSCmws8f2YeliCqGSkrtQ==",
 			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
+				"acorn": "^6.1.1",
+				"acorn-globals": "^4.3.2",
 				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
+				"cssom": "^0.3.6",
+				"cssstyle": "^1.2.2",
+				"data-urls": "^1.1.0",
 				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
+				"escodegen": "^1.11.1",
 				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
-				"parse5": "4.0.0",
+				"nwsapi": "^2.1.4",
+				"parse5": "5.1.0",
 				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
+				"request": "^2.88.0",
+				"request-promise-native": "^1.0.7",
+				"saxes": "^3.1.9",
 				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
+				"tough-cookie": "^3.0.1",
 				"w3c-hr-time": "^1.0.1",
+				"w3c-xmlserializer": "^1.1.2",
 				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^7.0.0",
+				"ws": "^7.0.0",
 				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"dev": true
+				},
+				"escodegen": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+					"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+					"dev": true,
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					}
+				},
+				"tough-cookie": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+					"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+					"dev": true,
+					"requires": {
+						"ip-regex": "^2.1.0",
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"ws": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
+					"integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "^1.0.0"
+					}
+				}
 			}
 		},
 		"jsesc": {
@@ -5906,12 +6063,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
 			"integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
-			"dev": true
-		},
-		"left-pad": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
 			"dev": true
 		},
 		"level": {
@@ -6074,9 +6225,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
 		"lodash.assignin": {
@@ -6134,9 +6285,9 @@
 			"dev": true
 		},
 		"lodash.merge": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
 		"lodash.pick": {
@@ -6443,9 +6594,9 @@
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -6511,9 +6662,9 @@
 			}
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"nice-try": {
@@ -6621,9 +6772,9 @@
 			}
 		},
 		"normalize-html-whitespace": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-0.2.0.tgz",
-			"integrity": "sha1-EBci9kI1Ucdc24+dEE/4UNrx4Q4=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz",
+			"integrity": "sha512-9ui7CGtOOlehQu0t/OhhlmDyc71mKVlv+4vF+me4iZLPrNtRL2xoquEdfZxasC/bdQi/Hr3iTrpyRKIG+ocabA==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -6697,9 +6848,9 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
-			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+			"integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
 			"dev": true
 		},
 		"oauth-sign": {
@@ -7098,23 +7249,23 @@
 			"dev": true
 		},
 		"parcel": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/parcel/-/parcel-1.12.2.tgz",
-			"integrity": "sha512-Ye8EwEgkcj6JblcqTXVbJ3Rrr0lediOcRc4rEVvVX5v8bMGs9gkszGuStw3offujK6io5ocjemzAS0+FqBvUhw==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/parcel/-/parcel-1.12.3.tgz",
+			"integrity": "sha512-j9XCVLeol9qZvGemRKt2z8bptbXq9LVy8/IzjqWQKMiKd8DR0NpDAlRHV0zyF72/J/UUTsdsrhnw6UGo9nGI+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/core": "^7.0.0",
-				"@babel/generator": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
-				"@babel/plugin-transform-react-jsx": "^7.0.0",
-				"@babel/preset-env": "^7.0.0",
-				"@babel/runtime": "^7.0.0",
-				"@babel/template": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
+				"@babel/code-frame": "^7.0.0 <7.4.0",
+				"@babel/core": "^7.0.0 <7.4.0",
+				"@babel/generator": "^7.0.0 <7.4.0",
+				"@babel/parser": "^7.0.0 <7.4.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0 <7.4.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0 <7.4.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0 <7.4.0",
+				"@babel/preset-env": "^7.0.0 <7.4.0",
+				"@babel/runtime": "^7.0.0 <7.4.0",
+				"@babel/template": "^7.0.0 <7.4.0",
+				"@babel/traverse": "^7.0.0 <7.4.0",
+				"@babel/types": "^7.0.0 <7.4.0",
 				"@iarna/toml": "^2.2.0",
 				"@parcel/fs": "^1.11.0",
 				"@parcel/logger": "^1.11.0",
@@ -8776,9 +8927,9 @@
 			}
 		},
 		"parse5": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
 			"dev": true
 		},
 		"parseurl": {
@@ -10816,9 +10967,9 @@
 			"dev": true
 		},
 		"safer-eval": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.2.tgz",
-			"integrity": "sha512-mAkc9NX+ULPw4qX+lkFVuIhXQbjFaX97fWFj6atFXMG11lUX4rXfQY6Q0VFf1wfJfqCHYO7cxtC7cA8fIkWsLQ==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.5.tgz",
+			"integrity": "sha512-BJ//K2Y+EgCbOHEsDGS5YahYBcYy7JcFpKDo2ba5t4MnOGHYtk7HvQkcxTDFvjQvJ0CRcdas/PyF+gTTCay+3w==",
 			"dev": true,
 			"requires": {
 				"clones": "^1.2.0"
@@ -10838,6 +10989,15 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
+		},
+		"saxes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.1.1"
+			}
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -10919,9 +11079,9 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -11584,9 +11744,9 @@
 			}
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
 		"tar-fs": {
@@ -11868,42 +12028,83 @@
 			}
 		},
 		"uncss": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/uncss/-/uncss-0.16.2.tgz",
-			"integrity": "sha1-OyJpxZAS2nxmy+mPvt3e75TwZJw=",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/uncss/-/uncss-0.17.0.tgz",
+			"integrity": "sha512-ZFFHCpAUEC0kJkuJelLYjrr0/bHBlgrN8XRDQN+wt9VVqap8Avj4fxt2WDJJZi0aSzYVaWCQoX19ZM+JZ5lqnw==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.9.0",
-				"glob": "^7.0.3",
-				"is-absolute-url": "^2.0.0",
-				"is-html": "^1.0.0",
-				"jsdom": "^11.3.0",
-				"lodash": "^4.13.1",
-				"postcss": "^6.0.14",
-				"postcss-selector-parser": "3.1.1",
-				"request": "^2.72.0"
+				"commander": "^2.20.0",
+				"glob": "^7.1.4",
+				"is-absolute-url": "^3.0.0",
+				"is-html": "^1.1.0",
+				"jsdom": "^15.1.0",
+				"lodash": "^4.17.11",
+				"postcss": "^7.0.16",
+				"postcss-selector-parser": "6.0.2",
+				"request": "^2.88.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+				"commander": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+					"dev": true
+				},
+				"cssesc": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+					"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"is-absolute-url": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
+					"integrity": "sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"supports-color": "^6.1.0"
 					}
 				},
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"cssesc": "^3.0.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -11964,38 +12165,15 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {
@@ -12247,6 +12425,17 @@
 				"browser-process-hrtime": "^0.1.2"
 			}
 		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"dev": true,
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
 		"wait-on": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.2.0.tgz",
@@ -12291,9 +12480,9 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
@@ -12412,6 +12601,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xmlchars": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.1.1.tgz",
+			"integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w==",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
 	"devDependencies": {
 		"del-cli": "^1.1.0",
 		"gh-pages": "^2.0.1",
-		"handlebars": "^4.1.1",
+		"handlebars": "^4.1.2",
 		"http-server": "^0.11.1",
 		"pa11y-ci": "^2.2.0",
-		"parcel": "1.12.2",
+		"parcel": "^1.12.3",
 		"parcel-plugin-asset-copier": "^1.0.0",
 		"parcel-plugin-handlebars-precompile": "aevanson/parcel-plugin-handlebars-precompile",
 		"sass": "^1.19.0",


### PR DESCRIPTION
I have updated several npm packages to mitigate the npm audit failures. 
