### PR TITLE
Issue #242 - remove aria-label from checkboxes in filters, move skip …

### DIFF
--- a/src/components/product-filters/product-filters.hbs
+++ b/src/components/product-filters/product-filters.hbs
@@ -44,16 +44,16 @@
             </h3>
             <fieldset class="accordion__panel filter__options">
                 <legend id="colorLegend" class="sr-only">Filter by Colors</legend>
-                <input id="blue" data-js="filter" class="checkbox__input" aria-label="Filter on color blue" type="checkbox" name="color" value="blue">
+                <input id="blue" data-js="filter" class="checkbox__input" type="checkbox" name="color" value="blue">
                 <label for="blue" class="checkbox__label">Blue</label>
-                <input id="green" data-js="filter" class="checkbox__input" aria-label="Filter on color green" type="checkbox" name="color" value="green">
+                <input id="green" data-js="filter" class="checkbox__input" type="checkbox" name="color" value="green">
                 <label for="green" class="checkbox__label">Green</label>
-                <input id="yellow" data-js="filter" class="checkbox__input" aria-label="Filter on color yellow" type="checkbox" name="color" value="yellow">
+                <input id="yellow" data-js="filter" class="checkbox__input" type="checkbox" name="color" value="yellow">
                 <label for="yellow" class="checkbox__label">Yellow</label>
-                <input id="red" data-js="filter" class="checkbox__input" aria-label="Filter on color red" type="checkbox" name="color" value="red">
+                <input id="red" data-js="filter" class="checkbox__input" type="checkbox" name="color" value="red">
                 <label for="red" class="checkbox__label">Red</label>
-                <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
             </fieldset>
+            <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
         </li>
         <li class="filter">
             <h3 class="accordion__heading filter__heading">
@@ -67,14 +67,14 @@
             </h3>
             <fieldset class="accordion__panel filter__options">
                 <legend id="sizeLegend" class="sr-only">Filter by Size</legend>
-                <input id="large" data-js="filter" class="checkbox__input" aria-label="Filter on size large" type="checkbox" name="size" value="large" />
+                <input id="large" data-js="filter" class="checkbox__input" type="checkbox" name="size" value="large" />
                 <label for="large" class="checkbox__label">Large</label>
-                <input id="medium" data-js="filter" class="checkbox__input" aria-label="Filter on size medium" type="checkbox" name="size" value="medium">
+                <input id="medium" data-js="filter" class="checkbox__input" type="checkbox" name="size" value="medium">
                 <label for="medium" class="checkbox__label">Medium</label>
-                <input id="small" data-js="filter" class="checkbox__input" aria-label="Filter on size small" type="checkbox" name="size" value="small">
+                <input id="small" data-js="filter" class="checkbox__input" type="checkbox" name="size" value="small">
                 <label for="small" class="checkbox__label">Small</label>
-                <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
             </fieldset>
+            <a class="skip-link" href="#skip-to-products-from-filters">Skip to Products</a>
         </li>
         <li class="filter">
             <h3 class="accordion__heading filter__heading">


### PR DESCRIPTION
…link outside of fieldset

The aria-label is not needed anymore on the checkboxes since the right style is being applied on the <legend> resulting in the <legend> text getting announced when tabbing to each checkbox.

The Skip to Products link had to be moved outside of the <fieldset> because it was announcing as part of the group.